### PR TITLE
Fix java.lang.ClassNotFoundException: org.springframework.integration.twitter.core.Twitter4jTemplate

### DIFF
--- a/basic/twitter/src/test/resources/META-INF/spring/integration/TwitterSearch-context.xml
+++ b/basic/twitter/src/test/resources/META-INF/spring/integration/TwitterSearch-context.xml
@@ -12,7 +12,7 @@
 	<context:property-placeholder location="classpath:oauth.properties"/>
 
 	<bean id="twitterTemplate"
-		class="org.springframework.integration.twitter.core.Twitter4jTemplate">
+		class="org.springframework.social.twitter.api.impl.TwitterTemplate">
 		<constructor-arg value="${twitter.oauth.consumerKey}" />
 		<constructor-arg value="${twitter.oauth.consumerSecret}" />
 		<constructor-arg value="${twitter.oauth.accessToken}" />

--- a/basic/twitter/src/test/resources/META-INF/spring/integration/TwitterSendUpdates-context.xml
+++ b/basic/twitter/src/test/resources/META-INF/spring/integration/TwitterSendUpdates-context.xml
@@ -12,7 +12,7 @@
 	<context:property-placeholder location="classpath:oauth.properties"/>    
 	
 	<bean id="twitterTemplate"
-		class="org.springframework.integration.twitter.core.Twitter4jTemplate">
+		class="org.springframework.social.twitter.api.impl.TwitterTemplate">
 		<constructor-arg value="${twitter.oauth.consumerKey}" />
 		<constructor-arg value="${twitter.oauth.consumerSecret}" />
 		<constructor-arg value="${twitter.oauth.accessToken}" />

--- a/basic/twitter/src/test/resources/META-INF/spring/integration/TwitterTimelineUpdates-context.xml
+++ b/basic/twitter/src/test/resources/META-INF/spring/integration/TwitterTimelineUpdates-context.xml
@@ -12,7 +12,7 @@
 	<context:property-placeholder location="classpath:oauth.properties"/>
 
 	<bean id="twitterTemplate"
-		class="org.springframework.integration.twitter.core.Twitter4jTemplate">
+		class="org.springframework.social.twitter.api.impl.TwitterTemplate">
 		<constructor-arg value="${twitter.oauth.consumerKey}" />
 		<constructor-arg value="${twitter.oauth.consumerSecret}" />
 		<constructor-arg value="${twitter.oauth.accessToken}" />


### PR DESCRIPTION
The org.springframework.integration.twitter.core.Twitter4jTemplate class
was replaced with the org.springframework.social.twitter.api.impl.TwitterTemplate one
in the basic/twitter artifact.

Notes:
Only the org.springframework.integration.samples.twitter.TwitterTimelineUpdatesSample
test suite passes tests.

The org.springframework.integration.samples.twitter.TwitterSearchSample and
org.springframework.integration.samples.twitter.TwitterSendUpdatesSample test suites
are still red because of other circumstances.
