### PR TITLE
INTSAMPLES-65 - Basic File Sample (Text Copy) Has Incorrect Filter Attribute

### DIFF
--- a/basic/file/src/main/resources/META-INF/spring/integration/fileCopyDemo-text.xml
+++ b/basic/file/src/main/resources/META-INF/spring/integration/fileCopyDemo-text.xml
@@ -14,7 +14,7 @@
 
 	<file:inbound-channel-adapter id="filesIn"
 	                              directory="file:${java.io.tmpdir}/spring-integration-samples/input"
-	                              filename-pattern="[a-z]+.txt">
+	                              filename-regex="[a-z]+.txt">
 		<integration:poller id="poller" fixed-delay="5000"/>
 	</file:inbound-channel-adapter>
 


### PR DESCRIPTION
Reference: https://jira.springsource.org/browse/INTSAMPLES-65
- Change _filename-pattern_ attribute to _filename-regex_.
