### PR TITLE
INTSAMPLES-103 - fix classpath in applications/cafe-scripted/pom.xml

### DIFF
--- a/applications/cafe-scripted/pom.xml
+++ b/applications/cafe-scripted/pom.xml
@@ -150,7 +150,7 @@
 							<arguments>
 								<argument>-classpath</argument>
 								<classpath />
-								<argument>org.springframework.integration.samples.org.springframework.integration.samples.cafe.demo.CafeDemoApp</argument>
+								<argument>org.springframework.integration.samples.cafe.demo.CafeDemoApp</argument>
 								<argument>${lang}</argument>
 							</arguments>
 							<successCodes>
@@ -181,7 +181,7 @@
 							<arguments>
 								<argument>-classpath</argument>
 								<classpath />
-								<argument>org.springframework.integration.samples.org.springframework.integration.samples.cafe.demo.ControlBusMain</argument>
+								<argument>org.springframework.integration.samples.cafe.demo.ControlBusMain</argument>
 
 							</arguments>
 							<successCodes>


### PR DESCRIPTION
changed the classpath from:
org.springframework.integration.samples.org.springframework.integration.samples.cafe.demo.ControlBus
to:
org.springframework.integration.samples.cafe.demo.CafeDemoApp

to make the sample compile/run
