### PR TITLE
INTSAMPLES-106 JMS: Eliminate Hijack of stdout

### DIFF
--- a/basic/jms/README.md
+++ b/basic/jms/README.md
@@ -13,6 +13,8 @@ It also uses the following components:
 2. Stdout Channel Adapter (from Stream support Module)
 3. Stdin Channel Adapter (from Stream support Module)
 
+It also shows an example of using Spring profiles to modify the configuration for test cases.
+
 The Stdout and Stdin Channel Adapters will allow you to interact with JMS via the console. It uses an embedded ActiveMQ broker.
 
 To run the sample, simply execute the **Main** class located in the the *org.springframework.integration.samples.jms* package either from your favorite IDE or by using Maven. When using Maven you can start the sample by executing:
@@ -48,3 +50,5 @@ When running either one of the demos you will see the following prompt:
 * **GatewayDemo** uses the *DemoBean* service, which will echo the response and upper-casing it.
 * **ChannelAdapterDemo** will simply echo the response
 
+
+There are also test cases that exercise both demos; utilizing Spring 3.0 profiles to route the output to a QueueChannel instead of stdout.

--- a/basic/jms/src/main/resources/META-INF/spring/integration/inboundChannelAdapter.xml
+++ b/basic/jms/src/main/resources/META-INF/spring/integration/inboundChannelAdapter.xml
@@ -13,12 +13,27 @@
 			http://www.springframework.org/schema/integration/stream
 			http://www.springframework.org/schema/integration/stream/spring-integration-stream.xsd">
 
-	<jms:message-driven-channel-adapter id="jmsin"
+	<jms:message-driven-channel-adapter id="jmsIn"
 			destination="requestQueue"
-			channel="jmsinToStdoutChannel"/>
+			channel="jmsInChannel" />
 
-	<channel id="jmsinToStdoutChannel"/>
+	<channel id="jmsInChannel" />
 
-	<stream:stdout-channel-adapter id="stdout" channel="jmsinToStdoutChannel" append-newline="true"/>
+
+	<beans:beans profile="default">
+
+		<stream:stdout-channel-adapter id="stdout" channel="jmsInChannel" append-newline="true"/>
+
+	</beans:beans>
+
+	<beans:beans profile="testCase">
+
+		<bridge input-channel="jmsInChannel" output-channel="queueChannel"/>
+
+		<channel id="queueChannel">
+			<queue />
+		</channel>
+
+	</beans:beans>
 
 </beans:beans>

--- a/basic/jms/src/main/resources/META-INF/spring/integration/outboundGateway.xml
+++ b/basic/jms/src/main/resources/META-INF/spring/integration/outboundGateway.xml
@@ -21,10 +21,25 @@
 
 	<jms:outbound-gateway request-channel="stdinToJmsoutChannel"
 						  request-destination="requestQueue"
-						  reply-channel="jmsReplyToStdoutChannel"/>
+						  reply-channel="jmsReplyChannel"/>
 
-	<channel id="jmsReplyToStdoutChannel"/>
+	<channel id="jmsReplyChannel" />
 
-	<stream:stdout-channel-adapter channel="jmsReplyToStdoutChannel" append-newline="true"/>
+
+	<beans:beans profile="default">
+
+		<stream:stdout-channel-adapter channel="jmsReplyChannel" append-newline="true"/>
+
+	</beans:beans>
+
+	<beans:beans profile="testCase">
+
+		<bridge input-channel="jmsReplyChannel" output-channel="queueChannel"/>
+
+		<channel id="queueChannel">
+			<queue />
+		</channel>
+
+	</beans:beans>
 
 </beans:beans>

--- a/basic/jms/src/test/java/org/springframework/integration/samples/jms/ChannelAdapterDemoTest.java
+++ b/basic/jms/src/test/java/org/springframework/integration/samples/jms/ChannelAdapterDemoTest.java
@@ -15,15 +15,13 @@
  */
 package org.springframework.integration.samples.jms;
 
-import java.io.ByteArrayOutputStream;
-import java.io.PrintStream;
-
 import junit.framework.Assert;
 
-import org.junit.Before;
 import org.junit.Test;
 import org.springframework.context.support.GenericXmlApplicationContext;
+import org.springframework.integration.Message;
 import org.springframework.integration.MessageChannel;
+import org.springframework.integration.channel.QueueChannel;
 import org.springframework.integration.support.MessageBuilder;
 
 /**
@@ -37,29 +35,24 @@ public class ChannelAdapterDemoTest {
 		"/META-INF/spring/integration/outboundChannelAdapter.xml"
 	};
 
-	private final ByteArrayOutputStream out = new ByteArrayOutputStream();
-
-	@Before
-	public void setupStreams() {
-		System.setOut(new PrintStream(this.out));
-	}
-
-	private void resetStreams() {
-		this.out.reset();
-	}
-
 	@Test
 	public void testChannelAdapterDemo() throws InterruptedException {
+
+		System.setProperty("spring.profiles.active", "testCase");
 
 		final GenericXmlApplicationContext applicationContext = new GenericXmlApplicationContext(configFilesChannelAdapterDemo);
 
 		final MessageChannel stdinToJmsoutChannel = applicationContext.getBean("stdinToJmsoutChannel", MessageChannel.class);
 
-		resetStreams();
 		stdinToJmsoutChannel.send(MessageBuilder.withPayload("jms test").build());
 
-		Thread.sleep(1000);
-		Assert.assertEquals("jms test\n", out.toString());
+		final QueueChannel queueChannel = applicationContext.getBean("queueChannel", QueueChannel.class);
+
+		@SuppressWarnings("unchecked")
+		Message<String> reply = (Message<String>) queueChannel.receive(20000);
+		Assert.assertNotNull(reply);
+		String out = reply.getPayload();
+		Assert.assertEquals("jms test", out);
 
 		applicationContext.close();
 	}


### PR DESCRIPTION
Caused unusual behavior when exceptions occurred, or debug
logging enabled.

Now uses Spring profiles to route the output to a QueueChannel
instead.
