### PR TITLE
INTSAMPLES-114 Twitter Search Requires Authentication

### DIFF
--- a/basic/twitter/README.md
+++ b/basic/twitter/README.md
@@ -5,7 +5,7 @@ This example demonstrates the following aspects of the Twitter support available
 
 1. Twitter Inbound Channel Adapter - allows you to receive HOME status updates
 2. Twitter Inbound Search Channel Adapter - allows you to receive HOME status updates
-3. Twitter Outboud Channel Adapter - allows send status updates
+3. Twitter Outbound Channel Adapter - allows send status updates
 
 In order to run this sample you need to configure [OAuth][] and set the values in the [OAuth][] properties.
 

--- a/basic/twitter/pom.xml
+++ b/basic/twitter/pom.xml
@@ -12,7 +12,7 @@
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<spring.integration.version>2.2.0.RELEASE</spring.integration.version>
+		<spring.integration.version>2.2.4.RELEASE</spring.integration.version>
 		<log4j.version>1.2.17</log4j.version>
 		<junit.version>4.10</junit.version>
 	</properties>

--- a/basic/twitter/src/test/java/org/springframework/integration/samples/twitter/TwitterSearchSample.java
+++ b/basic/twitter/src/test/java/org/springframework/integration/samples/twitter/TwitterSearchSample.java
@@ -23,7 +23,7 @@ import org.springframework.context.support.ClassPathXmlApplicationContext;
  * @author Oleg Zhurakousky
  *
  */
-public class TwitterSearchSampleTest {
+public class TwitterSearchSample {
 
 	@Test
 	public void runDemo() throws Exception{

--- a/basic/twitter/src/test/resources/META-INF/spring/integration/TwitterSearch-context.xml
+++ b/basic/twitter/src/test/resources/META-INF/spring/integration/TwitterSearch-context.xml
@@ -11,9 +11,7 @@
 
 	<context:property-placeholder location="classpath:oauth.properties"/>
 
-<!-- While authentication is certainly support for executing Twitter searches,
-	 authentication is not required.  -->
-<!--
+	<!-- As of Twitter API version 1.1, users must be authenticated to perform searches -->
 
 	<bean id="twitterTemplate"
 		class="org.springframework.social.twitter.api.impl.TwitterTemplate">
@@ -24,15 +22,7 @@
 	</bean>
 
 	<int-twitter:search-inbound-channel-adapter id="searchAdapter" channel="sourceExtractor"
-		query="#springintegration" twitter-template="twitterTemplate">
-		<int:poller fixed-rate="3000" max-messages-per-poll="5" />
-	</int-twitter:search-inbound-channel-adapter>
-
--->
-
-	<!-- Search Twitter without authentication -->
-	<int-twitter:search-inbound-channel-adapter id="searchAdapter" channel="sourceExtractor"
-		query="springintegration OR springframework OR #grails">
+		query="springintegration OR springframework OR #grails" twitter-template="twitterTemplate">
 		<int:poller fixed-rate="3000" max-messages-per-poll="5" />
 	</int-twitter:search-inbound-channel-adapter>
 


### PR DESCRIPTION
- Update Sample to Spring Integration 2.2.4
- In the sample - disallow unauthenticated Twitter Searches
  - As of Twitter API version 1.1, users must be authenticated to perform searches.

For reference see: https://jira.springsource.org/browse/INTSAMPLES-114
