### PR TITLE
Added HBase sink + trigger on finish sample

### DIFF
--- a/applications/hbase-sink-with-trigger-on-finish/README.md
+++ b/applications/hbase-sink-with-trigger-on-finish/README.md
@@ -1,0 +1,9 @@
+HBase sink with trigger on finish Application
+=======================
+
+## Overview
+
+The *HBase sink with trigger on finish* implements the competing consumers pattern )multiple consumers on a queue) but adds the functionality to call a task (a mapreduce job on received data in this case) on the arrival of a stop message. 
+Moreover, the Controller consumer, waits for all other consumers to finish their processing before triggering its processing task (via Zookeeper/Curator).
+
+Feedbacks are welcome!

--- a/applications/hbase-sink-with-trigger-on-finish/client/pom.xml
+++ b/applications/hbase-sink-with-trigger-on-finish/client/pom.xml
@@ -1,0 +1,77 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>org.springframework.integration.samples</groupId>
+		<artifactId>hbase-sink-with-trigger-on-finish</artifactId>
+		<version>2.2.0.BUILD-SNAPSHOT</version>
+	</parent>
+	<groupId>org.springframework.integration.samples.client</groupId>
+	<artifactId>queue-client</artifactId>
+	<packaging>jar</packaging>
+	<name>Sample source of messages</name>
+
+	<dependencies>
+		<!-- Test dependencies -->
+		<dependency>
+			<groupId>org.springframework.integration.samples</groupId>
+			<artifactId>json-utils</artifactId>
+			<version>${project.version}</version>
+			<type>test-jar</type>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.commons</groupId>
+			<artifactId>commons-io</artifactId>
+			<version>1.3.2</version>
+			<scope>test</scope>
+		</dependency>
+
+		<!-- For MD5 hash -->
+		<dependency>
+			<groupId>commons-codec</groupId>
+			<artifactId>commons-codec</artifactId>
+			<version>1.8</version>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.amqp</groupId>
+			<artifactId>spring-rabbit</artifactId>
+			<version>${spring.rabbitmq.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.integration.samples</groupId>
+			<artifactId>json-utils</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+	</dependencies>
+
+	<build>
+		<pluginManagement>
+			<plugins>
+				<plugin>
+					<groupId>com.springsource.bundlor</groupId>
+					<artifactId>com.springsource.bundlor.maven</artifactId>
+					<version>1.0.0.M1B</version>
+				</plugin>
+				<plugin>
+					<artifactId>maven-assembly-plugin</artifactId>
+					<inherited>false</inherited>
+					<configuration>
+						<descriptorRefs>
+							<descriptorRef>project</descriptorRef>
+						</descriptorRefs>
+					</configuration>
+				</plugin>
+			</plugins>
+		</pluginManagement>
+		<plugins>
+			<plugin>
+				<groupId>org.mortbay.jetty</groupId>
+				<artifactId>maven-jetty-plugin</artifactId>
+				<version>6.1.26</version>
+			</plugin>
+		</plugins>
+	</build>
+
+
+</project>

--- a/applications/hbase-sink-with-trigger-on-finish/client/src/main/java/org/springframework/integration/samples/producer/gateway/HBaseGateway.java
+++ b/applications/hbase-sink-with-trigger-on-finish/client/src/main/java/org/springframework/integration/samples/producer/gateway/HBaseGateway.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2002-2010 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.integration.samples.producer.gateway;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.springframework.amqp.rabbit.core.support.RabbitGatewaySupport;
+import org.springframework.integration.samples.beans.DocumentToIndex;
+import org.springframework.integration.samples.beans.RoutingKey;
+import org.springframework.integration.samples.producer.gateway.interfaces.StorageGateway;
+
+/**
+ * Implementation of the {@link StorageGateway} for sending documents to the Buffer
+ * 
+ * @author Flavio Pompermaier
+ */
+public class HBaseGateway extends RabbitGatewaySupport implements StorageGateway {
+
+	private static Log logger = LogFactory.getLog(HBaseGateway.class);
+	
+	@Override
+	public void sendDocumentToPersist(DocumentToIndex d) {
+		final RoutingKey rk = d.getRoutingKey();
+		logger.info("Sending document to route " + rk);
+		getRabbitTemplate().convertAndSend(rk.toString(), d);
+	}
+
+}

--- a/applications/hbase-sink-with-trigger-on-finish/client/src/main/java/org/springframework/integration/samples/producer/gateway/interfaces/StorageGateway.java
+++ b/applications/hbase-sink-with-trigger-on-finish/client/src/main/java/org/springframework/integration/samples/producer/gateway/interfaces/StorageGateway.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2002-2010 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.integration.samples.producer.gateway.interfaces;
+
+import org.springframework.integration.samples.beans.DocumentToIndex;
+
+/**
+ * Gateway interface for sending document to a buffer that stores received data to HBase
+ * 
+ * @author Flavio Pompermaier
+ *
+ */
+public interface StorageGateway {
+
+	void sendDocumentToPersist(DocumentToIndex d);
+}

--- a/applications/hbase-sink-with-trigger-on-finish/client/src/main/resources/log4j.properties
+++ b/applications/hbase-sink-with-trigger-on-finish/client/src/main/resources/log4j.properties
@@ -1,0 +1,11 @@
+log4j.rootCategory=INFO, stdout
+
+log4j.appender.stdout=org.apache.log4j.ConsoleAppender
+log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
+
+#log4j.appender.stdout.layout.ConversionPattern=%d %p [%c] - <%m>%n
+log4j.appender.stdout.layout.ConversionPattern=%-5p [%40.40c{4}]: %m%n
+
+log4j.category.org.springframework.amqp.rabbit=INFO
+log4j.category.org.springframework.beans.factory=INFO
+

--- a/applications/hbase-sink-with-trigger-on-finish/client/src/main/resources/sample-buffer.properties
+++ b/applications/hbase-sink-with-trigger-on-finish/client/src/main/resources/sample-buffer.properties
@@ -1,0 +1,10 @@
+# host and port where RabbitMQ broker is hosted
+queue.host=localhost
+queue.port=5672
+# credentials used to connect
+queue.username=guest
+queue.password=guest
+
+# direct exchange name
+test.direct.exchange=test.direct.exchange
+ 

--- a/applications/hbase-sink-with-trigger-on-finish/client/src/test/java/org/springframework/integration/samples/producer/test/QueueProducer.java
+++ b/applications/hbase-sink-with-trigger-on-finish/client/src/test/java/org/springframework/integration/samples/producer/test/QueueProducer.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2002-2010 the original author or authors.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package org.springframework.integration.samples.producer.test;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.nio.ByteBuffer;
+import java.nio.charset.Charset;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.Date;
+
+import org.junit.After;
+import org.junit.Test;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.context.support.ClassPathXmlApplicationContext;
+import org.springframework.integration.samples.beans.DocumentToIndex;
+import org.springframework.integration.samples.beans.RoutingKey;
+import org.springframework.integration.samples.producer.gateway.HBaseGateway;
+
+import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+/**
+ * Main client application, can run as an application or unit test.
+ * 
+ * @author Flavio Pompermaier
+ */
+public class QueueProducer {
+
+	private ConfigurableApplicationContext context;
+
+	public static void main(String[] args) throws JsonParseException, JsonMappingException, IOException, URISyntaxException {
+		new QueueProducer().run();
+	}
+
+	@Test
+	public void run() throws JsonParseException, JsonMappingException, IOException, URISyntaxException {
+		context = new ClassPathXmlApplicationContext("bootstrap-config.xml");
+		
+		final URL resource = getClass().getResource("/queue");
+		URI detectionsFolderUri = resource.toURI();
+		File samplesDir = new File(detectionsFolderUri);
+		
+		Date startDate = new Date();
+		HBaseGateway queueGateway = (HBaseGateway) context.getBean("hbaseGateway");
+		//test detections
+		for (File file : samplesDir.listFiles()) {
+			String jsonString = readFile(file);
+			DocumentToIndex d = new ObjectMapper().readValue(jsonString, DocumentToIndex.class);
+			queueGateway.sendDocumentToPersist(d);
+		}
+		//test end of process
+		DocumentToIndex d = new DocumentToIndex();
+		d.setRoutingKey(RoutingKey.mysource);
+		d.setSource(RoutingKey.mysource.toString());
+		d.setStop(true);
+		d.setStartTimestamp(startDate.getTime());
+		queueGateway.sendDocumentToPersist(d);
+	}
+	static String readFile(File file) throws IOException {
+		Charset encoding = Charset.forName("UTF-8");
+		byte[] encoded = Files.readAllBytes(Paths.get(file.toURI()));
+		return encoding.decode(ByteBuffer.wrap(encoded)).toString();
+	}
+	@After
+	public void close() {
+		if (context != null) {
+			context.close();
+		}
+	}
+
+}

--- a/applications/hbase-sink-with-trigger-on-finish/client/src/test/resources/bootstrap-config.xml
+++ b/applications/hbase-sink-with-trigger-on-finish/client/src/test/resources/bootstrap-config.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:context="http://www.springframework.org/schema/context"
+	xmlns:task="http://www.springframework.org/schema/task" xmlns:rabbit="http://www.springframework.org/schema/rabbit"
+	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+		http://www.springframework.org/schema/task http://www.springframework.org/schema/task/spring-task-3.0.xsd
+		http://www.springframework.org/schema/rabbit http://www.springframework.org/schema/rabbit/spring-rabbit.xsd
+		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.0.xsd">
+
+	<context:property-placeholder location="classpath:/sample-buffer.properties" />
+
+	<rabbit:connection-factory id="connectionFactory"
+		host="${queue.host}" 
+		username="${queue.username}"
+		password="${queue.password}"
+		port="${queue.port}" />
+
+	<!-- <rabbit:admin connection-factory="connectionFactory"/> -->
+
+	<bean id="jsonMessageConverter"
+		class="org.springframework.amqp.support.converter.Jackson2JsonMessageConverter" />
+	
+	<rabbit:template id="rabbitTemplate"
+		connection-factory="connectionFactory" 
+		message-converter="jsonMessageConverter"
+		exchange="${test.direct.exchange}" />
+
+	<bean id="hbaseGateway" name="hbaseGateway"
+		class="org.springframework.integration.samples.producer.gateway.HBaseGateway">
+		<property name="rabbitTemplate" ref="rabbitTemplate" />
+	</bean>
+
+	<!-- <task:scheduled-tasks> -->
+	<!-- <task:scheduled ref="hbaseGateway" method="sendDocumentToPersist" fixed-delay="1000"/> -->
+	<!-- <task:scheduled ref="hbaseGateway" method="sendDocumentToPersist" fixed-delay="1000"/> -->
+	<!-- </task:scheduled-tasks> -->
+</beans>

--- a/applications/hbase-sink-with-trigger-on-finish/client/src/test/resources/queue/sample1.json
+++ b/applications/hbase-sink-with-trigger-on-finish/client/src/test/resources/queue/sample1.json
@@ -1,0 +1,25 @@
+{
+"id": "8b9b6080-f889-11e2-b778-0800200c9a66",
+"routing-key" : "mysource",
+"source" : "mysource",
+"docs": [
+    {
+		"url": "URLn",
+        "meta": {
+            "timestamp": 1372413068,
+            "language": "en",
+            "categories": ["politics","computer","economics"]
+        	},
+        "text": "some text"
+   },
+   {
+		"url": "URL1",
+        "meta": {
+        	"timestamp": 1372411068,
+            "language": "en",
+            "categories":  ["economics"]
+        	},
+        "text": "some other text"
+    }
+    ]
+}

--- a/applications/hbase-sink-with-trigger-on-finish/client/src/test/resources/queue/sample2.json
+++ b/applications/hbase-sink-with-trigger-on-finish/client/src/test/resources/queue/sample2.json
@@ -1,0 +1,25 @@
+{
+"id": "8b9b6080-f889-11e2-b778-0800200c9a67",
+"routing-key" : "mysource",
+"source" : "mysource",
+"docs": [
+    {
+		"url": "URL3",
+        "meta": {
+            "timestamp": 1372413068,
+            "language": "en",
+            "categories": ["somecat"]
+        	},
+        "text": "some text for sample 2"
+   },
+   {
+		"url": "URL1",
+        "meta": {
+        	"timestamp": 1372411068,
+            "language": "en",
+            "categories":  ["economics", "gossip"]
+        	},
+        "text": "some other text for sample 2"
+    }
+    ]
+}

--- a/applications/hbase-sink-with-trigger-on-finish/client/src/test/resources/queue/sample3.json
+++ b/applications/hbase-sink-with-trigger-on-finish/client/src/test/resources/queue/sample3.json
@@ -1,0 +1,25 @@
+{
+"id": "8b9b6080-f889-11e2-b778-0800200c9a68",
+"routing-key" : "mysource",
+"source" : "mysource",
+"docs": [
+    {
+		"url": "URLn",
+        "meta": {
+            "timestamp": 1372413068,
+            "language": "de",
+            "categories": ["computer"]
+        	},
+        "text": "some text for sample 3"
+   },
+   {
+		"url": "URL5",
+        "meta": {
+        	"timestamp": 1372411068,
+            "language": "en",
+            "categories":  ["economics"]
+        	},
+        "text": "some other text for sample 3"
+    }
+    ]
+}

--- a/applications/hbase-sink-with-trigger-on-finish/commons/pom.xml
+++ b/applications/hbase-sink-with-trigger-on-finish/commons/pom.xml
@@ -1,0 +1,108 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>org.springframework.integration.samples</groupId>
+		<artifactId>hbase-sink-with-trigger-on-finish</artifactId>
+		<version>2.2.0.BUILD-SNAPSHOT</version>
+	</parent>
+	<groupId>org.springframework.integration.samples</groupId>
+	<artifactId>json-utils</artifactId>
+	<packaging>jar</packaging>
+	<name>JSON utilities</name>
+
+	<dependencies>
+		<!-- Test dependencies -->
+		<dependency>
+			<groupId>org.apache.commons</groupId>
+			<artifactId>commons-io</artifactId>
+			<version>1.3.2</version>
+			<scope>test</scope>
+		</dependency>
+
+		<!-- Log4j -->
+		<dependency>
+			<groupId>log4j</groupId>
+			<artifactId>log4j</artifactId>
+			<version>1.2.17</version>
+			<scope>runtime</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>com.fasterxml.jackson.core</groupId>
+			<artifactId>jackson-annotations</artifactId>
+			<version>${jackson.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>com.fasterxml.jackson.core</groupId>
+			<artifactId>jackson-core</artifactId>
+			<version>${jackson.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>com.fasterxml.jackson.core</groupId>
+			<artifactId>jackson-databind</artifactId>
+			<version>${jackson.version}</version>
+			<exclusions>
+				<exclusion>
+					<artifactId>jackson-annotations</artifactId>
+					<groupId>com.fasterxml.jackson.core</groupId>
+				</exclusion>
+				<exclusion>
+					<artifactId>jackson-core</artifactId>
+					<groupId>com.fasterxml.jackson.core</groupId>
+				</exclusion>
+			</exclusions>
+		</dependency>
+
+		<!-- Lombok for automatic setter/getters generation -->
+		<dependency>
+			<groupId>org.projectlombok</groupId>
+			<artifactId>lombok</artifactId>
+			<version>0.11.8</version>
+		</dependency>
+	</dependencies>
+
+	<build>
+		<pluginManagement>
+			<plugins>
+				<plugin>
+					<groupId>com.springsource.bundlor</groupId>
+					<artifactId>com.springsource.bundlor.maven</artifactId>
+					<version>1.0.0.M1B</version>
+				</plugin>
+				<plugin>
+					<artifactId>maven-assembly-plugin</artifactId>
+					<inherited>false</inherited>
+					<configuration>
+						<descriptorRefs>
+							<descriptorRef>project</descriptorRef>
+						</descriptorRefs>
+					</configuration>
+				</plugin>
+			</plugins>
+		</pluginManagement>
+		<plugins>
+			<plugin>
+				<groupId>org.mortbay.jetty</groupId>
+				<artifactId>maven-jetty-plugin</artifactId>
+				<version>6.1.26</version>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-jar-plugin</artifactId>
+				<version>2.2</version>
+				<executions>
+					<execution>
+						<goals>
+							<goal>test-jar</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
+
+	
+</project>

--- a/applications/hbase-sink-with-trigger-on-finish/commons/src/main/java/org/springframework/integration/samples/beans/Document.java
+++ b/applications/hbase-sink-with-trigger-on-finish/commons/src/main/java/org/springframework/integration/samples/beans/Document.java
@@ -1,0 +1,15 @@
+package org.springframework.integration.samples.beans;
+
+import java.util.List;
+
+import lombok.Data;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@Data
+public class Document {
+
+	private String url;
+	private DocumentMeta  meta;
+	private String text;
+}

--- a/applications/hbase-sink-with-trigger-on-finish/commons/src/main/java/org/springframework/integration/samples/beans/DocumentMeta.java
+++ b/applications/hbase-sink-with-trigger-on-finish/commons/src/main/java/org/springframework/integration/samples/beans/DocumentMeta.java
@@ -1,0 +1,12 @@
+package org.springframework.integration.samples.beans;
+
+import java.util.List;
+
+import lombok.Data;
+
+@Data
+public class DocumentMeta {
+	private long timestamp;
+	private String language;
+	private List<String> categories;
+}

--- a/applications/hbase-sink-with-trigger-on-finish/commons/src/main/java/org/springframework/integration/samples/beans/DocumentToIndex.java
+++ b/applications/hbase-sink-with-trigger-on-finish/commons/src/main/java/org/springframework/integration/samples/beans/DocumentToIndex.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2002-2010 the original author or authors.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package org.springframework.integration.samples.beans;
+
+import java.util.List;
+
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Domain object representing a document to index.
+ * Set stop to true only if the processing of document has finished!
+ * 
+ * @author Flavio Pompermaier
+ */
+@Data
+@EqualsAndHashCode(of="id")
+public class DocumentToIndex {
+
+	private String id;
+	@JsonProperty("routing-key")
+	private RoutingKey routingKey;
+	private String source;
+	private List<Document> docs;
+	private boolean stop;
+	private long startTimestamp;
+	
+}

--- a/applications/hbase-sink-with-trigger-on-finish/commons/src/main/java/org/springframework/integration/samples/beans/ProcessedDocument.java
+++ b/applications/hbase-sink-with-trigger-on-finish/commons/src/main/java/org/springframework/integration/samples/beans/ProcessedDocument.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2002-2010 the original author or authors.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package org.springframework.integration.samples.beans;
+
+import java.util.UUID;
+
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+/**
+ * Domain object representing a transformed document
+ * 
+ * @author Flavio Pompermaier
+ */
+@Data
+@EqualsAndHashCode(of="id")
+public class ProcessedDocument {
+
+	private final String id = UUID.randomUUID().toString();
+	private String url;
+	private String source;
+	private DocumentMeta meta;
+	private String text;
+		
+}

--- a/applications/hbase-sink-with-trigger-on-finish/commons/src/main/java/org/springframework/integration/samples/beans/RoutingKey.java
+++ b/applications/hbase-sink-with-trigger-on-finish/commons/src/main/java/org/springframework/integration/samples/beans/RoutingKey.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2002-2010 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.integration.samples.beans;
+
+/**
+ * Enumerations for the RoutingKeys used in the application to allow for a more fluent API
+ * style when configuring the broker in code.
+ * 
+ * @author Mark Pollack
+ */
+public enum RoutingKey {
+
+	mysource, secondstep;
+}

--- a/applications/hbase-sink-with-trigger-on-finish/commons/src/main/java/org/springframework/integration/samples/beans/control/RestartMessage.java
+++ b/applications/hbase-sink-with-trigger-on-finish/commons/src/main/java/org/springframework/integration/samples/beans/control/RestartMessage.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2002-2010 the original author or authors.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package org.springframework.integration.samples.beans.control;
+
+import java.util.UUID;
+
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+/**
+ * Domain object representing a document to index.
+ * Set stop to true only if the processing of document has finished!
+ * 
+ * @author Flavio Pompermaier
+ */
+@Data
+@EqualsAndHashCode(of="id")
+public class RestartMessage {
+
+	private final String id = UUID.randomUUID().toString();
+
+}

--- a/applications/hbase-sink-with-trigger-on-finish/commons/src/main/java/org/springframework/integration/samples/beans/control/StopMessage.java
+++ b/applications/hbase-sink-with-trigger-on-finish/commons/src/main/java/org/springframework/integration/samples/beans/control/StopMessage.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2002-2010 the original author or authors.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package org.springframework.integration.samples.beans.control;
+
+import java.util.UUID;
+
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+/**
+ *  
+ * @author Flavio Pompermaier
+ */
+@Data
+@EqualsAndHashCode(of="id")
+public class StopMessage {
+
+	private final String id = UUID.randomUUID().toString();
+
+//	@JsonProperty("routing-key")
+//	private final RoutingKey rk;
+	private long timestamp;
+	private String source;
+	
+}

--- a/applications/hbase-sink-with-trigger-on-finish/commons/src/main/resources/log4j.properties
+++ b/applications/hbase-sink-with-trigger-on-finish/commons/src/main/resources/log4j.properties
@@ -1,0 +1,10 @@
+log4j.rootCategory=INFO, stdout
+
+log4j.appender.stdout=org.apache.log4j.ConsoleAppender
+log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
+
+#log4j.appender.stdout.layout.ConversionPattern=%d %p [%c] - <%m>%n
+log4j.appender.stdout.layout.ConversionPattern=%-5p [%40.40c{4}]: %m%n
+
+log4j.category.org.springframework.amqp.rabbit=INFO
+log4j.category.org.springframework.beans.factory=INFO

--- a/applications/hbase-sink-with-trigger-on-finish/commons/src/test/java/org/springframework/integration/samples/json/test/JsonMocksGenerator.java
+++ b/applications/hbase-sink-with-trigger-on-finish/commons/src/test/java/org/springframework/integration/samples/json/test/JsonMocksGenerator.java
@@ -1,0 +1,63 @@
+package org.springframework.integration.samples.json.test;
+
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+
+import org.springframework.integration.samples.beans.Document;
+import org.springframework.integration.samples.beans.DocumentMeta;
+import org.springframework.integration.samples.beans.DocumentToIndex;
+import org.springframework.integration.samples.beans.RoutingKey;
+
+public class JsonMocksGenerator {
+	static final RoutingKey rk = RoutingKey.mysource;
+	
+	public static DocumentToIndex generateFakeDocument() {
+		Document doc1 = getDoc1();
+		Document doc2 = getDoc2();
+
+		List<Document> docs = new ArrayList<Document>();
+		docs.add(doc1);
+		docs.add(doc2);
+
+		final DocumentToIndex documentToIndex = new DocumentToIndex();
+		documentToIndex.setRoutingKey(rk);
+		documentToIndex.setSource(rk.toString());
+		documentToIndex.setId(1+"");
+		documentToIndex.setDocs(docs);
+		return documentToIndex;
+	}
+	public static  Document getDoc2() {
+		List<String> doc2categories = new ArrayList<String>();
+		doc2categories.add("economics");
+		DocumentMeta doc2meta = new DocumentMeta();
+		doc2meta.setTimestamp(new Date().getTime());
+		doc2meta.setCategories(doc2categories);
+		doc2meta.setLanguage("en");
+
+		Document doc2 = new Document();
+		doc2.setUrl("URL1");
+		doc2.setMeta(doc2meta);
+		doc2.setText("Some other text");
+		return doc2;
+	}
+
+	public static  Document getDoc1() {
+		List<String> doc1categories = new ArrayList<String>();
+		doc1categories.add("politics");
+		doc1categories.add("computer");
+		doc1categories.add("economics");
+
+		DocumentMeta doc1meta = new DocumentMeta();
+		doc1meta.setTimestamp(new Date().getTime());
+		doc1meta.setCategories(doc1categories);
+		doc1meta.setLanguage("en");
+
+		Document doc1 = new Document();
+		doc1.setUrl("URLn");
+		doc1.setMeta(doc1meta);
+		doc1.setText("Some text");
+		return doc1;
+	}
+
+}

--- a/applications/hbase-sink-with-trigger-on-finish/commons/src/test/java/org/springframework/integration/samples/json/test/Serialization.java
+++ b/applications/hbase-sink-with-trigger-on-finish/commons/src/test/java/org/springframework/integration/samples/json/test/Serialization.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2002-2010 the original author or authors.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package org.springframework.integration.samples.json.test;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
+
+import org.apache.commons.io.FileUtils;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.integration.samples.beans.Document;
+
+import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+/**
+ * Main client application, can run as an application or unit test.
+ * 
+ * @author Flavio Pompermaier
+ */
+public class Serialization {
+
+	final String OUTPUT_TEST_FOLDER = "/output";
+	final String DOCUMENT_OUTPUT_FILE = "document.json";
+	final String ENTITY_OUTPUT_FILE = "bill-gates.json";
+	private ObjectMapper mapper;
+	
+	@Before 
+	public void init(){
+		mapper = new ObjectMapper();
+	}
+	@Test
+	public void testSerializationOfDocument() throws JsonParseException,
+			JsonMappingException, IOException, URISyntaxException {
+		final URL resource = getClass().getResource("/");
+		URI testBaseFolder = resource.toURI();
+		File outputDir = new File(new File(testBaseFolder), OUTPUT_TEST_FOLDER);
+		File outputFile = new File(outputDir, DOCUMENT_OUTPUT_FILE);
+
+		Document doc = JsonMocksGenerator.getDoc1();
+		String json = mapper.writeValueAsString(doc);
+		FileUtils.writeStringToFile(outputFile, json, "UTF-8");
+	}
+
+	
+}

--- a/applications/hbase-sink-with-trigger-on-finish/pom.xml
+++ b/applications/hbase-sink-with-trigger-on-finish/pom.xml
@@ -1,0 +1,93 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<groupId>org.springframework.integration.samples</groupId>
+	<artifactId>hbase-sink-with-trigger-on-finish</artifactId>
+	<packaging>pom</packaging>
+	<version>2.2.0.BUILD-SNAPSHOT</version>
+
+	<prerequisites>
+		<maven>2.2.1</maven>
+	</prerequisites>
+
+	<name>Samples (Applications) - HBase sink with trigger on finish</name>
+
+	<properties>
+		<maven.test.failure.ignore>true</maven.test.failure.ignore>
+		<spring.framework.version>3.1.4.RELEASE</spring.framework.version>
+		<spring.amqp.version>1.2.0.RELEASE</spring.amqp.version>
+		<spring.rabbitmq.version>1.2.0.RELEASE</spring.rabbitmq.version>
+		<jackson.version>2.2.2</jackson.version>
+		<solrj.version>4.3.1</solrj.version>
+		<log4j.version>1.2.17</log4j.version>
+		<junit.version>4.10</junit.version>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+
+		<hadoop.core.version>1.0.4</hadoop.core.version>
+		<hbase.version>0.94.7</hbase.version>
+	</properties>
+
+	<profiles>
+		<profile>
+			<id>strict</id>
+			<properties>
+				<maven.test.failure.ignore>false</maven.test.failure.ignore>
+			</properties>
+		</profile>
+	</profiles>
+	
+	<dependencies>
+		<!-- Test dependencies -->
+		<dependency>
+			<groupId>junit</groupId>
+			<artifactId>junit</artifactId>
+			<version>${junit.version}</version>
+			<scope>test</scope>
+		</dependency>
+	</dependencies>
+	<modules>
+		<module>commons</module>
+		<module>client</module>
+		<module>server</module>
+	</modules>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<version>2.3.2</version>
+				<configuration>
+					<source>1.6</source>
+					<target>1.6</target>
+					<compilerArgument>-Xlint:all</compilerArgument>
+					<showWarnings>true</showWarnings>
+					<showDeprecation>true</showDeprecation>
+				</configuration>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-surefire-plugin</artifactId>
+				<version>2.9</version>
+				<configuration>
+					<!--forkMode>pertest</forkMode -->
+					<includes>
+						<include>**/*Tests.java</include>
+					</includes>
+					<excludes>
+						<exclude>**/Abstract*.java</exclude>
+					</excludes>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
+	
+	<repositories>
+		<repository>
+			<id>repo.springsource.org.milestone</id>
+			<name>SpringSource Maven Milestone Repository</name>
+			<url>https://repo.springsource.org/libs-milestone</url>
+		</repository>
+	</repositories>
+</project>

--- a/applications/hbase-sink-with-trigger-on-finish/server/consumer/README.md
+++ b/applications/hbase-sink-with-trigger-on-finish/server/consumer/README.md
@@ -1,0 +1,4 @@
+Run first org.springframework.integration.samples.server.Contoller and then 
+org.springframework.integration.samples.server.Consumer. 
+If client send them messages, they will store them in Bbase and, once finished,
+ they could run some task in ControlWorker.triggerDataTransformation()

--- a/applications/hbase-sink-with-trigger-on-finish/server/consumer/pom.xml
+++ b/applications/hbase-sink-with-trigger-on-finish/server/consumer/pom.xml
@@ -1,0 +1,108 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>org.springframework.integration.server</groupId>
+		<artifactId>server</artifactId>
+		<version>2.2.0.BUILD-SNAPSHOT</version>
+	</parent>
+	<artifactId>consumer</artifactId>
+	<packaging>jar</packaging>
+	<name>Spring AMQP queue consumer</name>
+	<url>http://www.springframework.org</url>
+	<description>This project shows the usage of Spring AMQP integration classes</description>
+
+	<dependencyManagement>
+		<dependencies>
+			<dependency>
+				<groupId>org.springframework</groupId>
+				<artifactId>spring-core</artifactId>
+				<version>${spring.framework.version}</version>
+			</dependency>
+		</dependencies>
+	</dependencyManagement>
+	<dependencies>
+		<dependency>
+			<groupId>org.springframework</groupId>
+			<artifactId>spring-test</artifactId>
+			<version>${spring.framework.version}</version>
+			<scope>test</scope>
+		</dependency>
+		<!-- Spring AMQP -->
+		<dependency>
+			<groupId>org.springframework.amqp</groupId>
+			<artifactId>spring-amqp</artifactId>
+			<version>${spring.amqp.version}</version>
+		</dependency>
+		<!-- Spring framework -->
+		<dependency>
+			<groupId>org.springframework</groupId>
+			<artifactId>spring-context-support</artifactId>
+			<version>${spring.framework.version}</version>
+			<scope>runtime</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework</groupId>
+			<artifactId>spring-aop</artifactId>
+			<version>${spring.framework.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework</groupId>
+			<artifactId>spring-oxm</artifactId>
+			<version>${spring.framework.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.aspectj</groupId>
+			<artifactId>aspectjrt</artifactId>
+			<version>1.5.4</version>
+		</dependency>
+		<dependency>
+			<groupId>org.aspectj</groupId>
+			<artifactId>aspectjweaver</artifactId>
+			<version>1.5.4</version>
+		</dependency>
+
+	
+		<!-- Zookeeper management -->
+		<dependency>
+			<groupId>org.springframework.integration.samples.server</groupId>
+			<artifactId>curator</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+		<!-- HBase utils -->
+		<dependency>
+			<groupId>org.springframework.integration.samples.server</groupId>
+			<artifactId>persistence</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+	</dependencies>
+
+	<build>
+		<pluginManagement>
+			<plugins>
+				<plugin>
+					<groupId>com.springsource.bundlor</groupId>
+					<artifactId>com.springsource.bundlor.maven</artifactId>
+					<version>1.0.0.M1B</version>
+				</plugin>
+				<plugin>
+					<artifactId>maven-assembly-plugin</artifactId>
+					<inherited>false</inherited>
+					<configuration>
+						<descriptorRefs>
+							<descriptorRef>project</descriptorRef>
+						</descriptorRefs>
+					</configuration>
+				</plugin>
+			</plugins>
+		</pluginManagement>
+		<plugins>
+			<plugin>
+				<groupId>org.mortbay.jetty</groupId>
+				<artifactId>maven-jetty-plugin</artifactId>
+				<version>6.1.26</version>
+			</plugin>
+		</plugins>
+	</build>
+
+</project>

--- a/applications/hbase-sink-with-trigger-on-finish/server/consumer/script/run-mysource-consumer.sh
+++ b/applications/hbase-sink-with-trigger-on-finish/server/consumer/script/run-mysource-consumer.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+#
+# Run an analysis of the dataset to print out statistics
+export MAVEN_OPTS="-Xmx10g"
+
+cd ..
+
+mvn exec:java -Dexec.mainClass="org.springframework.integration.samples.server.Consumer" -Dexec.args="mysource"

--- a/applications/hbase-sink-with-trigger-on-finish/server/consumer/script/run-mysource-controller.sh
+++ b/applications/hbase-sink-with-trigger-on-finish/server/consumer/script/run-mysource-controller.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+#
+# Run an analysis of the dataset to print out statistics
+export MAVEN_OPTS="-Xmx10g"
+
+cd ..
+
+mvn exec:java -Dexec.mainClass="org.springframework.integration.samples.server.Controller" -Dexec.args="mysource"

--- a/applications/hbase-sink-with-trigger-on-finish/server/consumer/src/main/java/org/springframework/integration/samples/managers/QueueFinalizer.java
+++ b/applications/hbase-sink-with-trigger-on-finish/server/consumer/src/main/java/org/springframework/integration/samples/managers/QueueFinalizer.java
@@ -1,0 +1,52 @@
+package org.springframework.integration.samples.managers;
+
+import java.io.IOException;
+
+import org.apache.curator.framework.CuratorFramework;
+import org.apache.hadoop.hbase.client.HTable;
+import org.apache.log4j.Logger;
+import org.springframework.amqp.rabbit.listener.AbstractMessageListenerContainer;
+import org.springframework.integration.samples.zookeeper.ZkUtils;
+
+public class QueueFinalizer implements Runnable {
+
+	private static final Logger LOG = Logger.getLogger(QueueFinalizer.class);
+	private final AbstractMessageListenerContainer listenerContainer;
+	private final HTable inputTableName;
+	private final String zkPersistentPath;
+	private final String zkNodeName;
+	private final CuratorFramework zkClient;
+	
+	public QueueFinalizer(AbstractMessageListenerContainer l, HTable table, 
+			CuratorFramework zkClient, String zkPersistentPath, String zkNodeName) {
+		this.listenerContainer = l;
+		this.inputTableName = table;
+		this.zkNodeName = zkNodeName;
+		this.zkPersistentPath = zkPersistentPath;
+		this.zkClient = zkClient;
+	}
+
+	@Override
+	public void run() {
+		LOG.info("Waiting for this consumer threads to stop ["+zkNodeName+"]");
+		listenerContainer.stop();
+		flushCommits();
+		String infoMsg = "Tell zookeper to remove this node [%s/%s]";
+		infoMsg = String.format(infoMsg, zkPersistentPath,zkNodeName);
+		LOG.info(infoMsg);
+		ZkUtils.remove(zkClient, zkPersistentPath, zkNodeName);
+		//restart listening on the queue
+		listenerContainer.start();
+	}
+
+	private void flushCommits() {
+		if(inputTableName==null)
+			return;
+		try {
+			inputTableName.flushCommits();
+		} catch (IOException e1) {
+			e1.printStackTrace();
+		}
+	}
+
+}

--- a/applications/hbase-sink-with-trigger-on-finish/server/consumer/src/main/java/org/springframework/integration/samples/server/Consumer.java
+++ b/applications/hbase-sink-with-trigger-on-finish/server/consumer/src/main/java/org/springframework/integration/samples/server/Consumer.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2002-2010 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.integration.samples.server;
+
+import org.apache.log4j.Logger;
+import org.springframework.amqp.rabbit.listener.AbstractMessageListenerContainer;
+import org.springframework.beans.factory.NoSuchBeanDefinitionException;
+import org.springframework.context.support.ClassPathXmlApplicationContext;
+import org.springframework.integration.samples.server.workers.QueueWorker;
+
+/**
+ * Server application than can be run as an app or unit test.
+ * 
+ * @author Flavio Pompermaier
+ */
+public class Consumer {
+
+	private static Logger LOG = Logger.getLogger(Consumer.class);
+	private static ClassPathXmlApplicationContext context;
+
+	public static void main(String[] args) {
+		final String confName = args[0];
+		context = new ClassPathXmlApplicationContext(confName
+				+ "-consumer/bootstrap-config.xml");
+		configMySourceWorker();
+//		configOtherSourceWorker();
+		LOG.info("Queue consumer " + confName + " isRunning(): " + context.isRunning());
+	}
+
+//	private static void configOtherSourceWorker() {
+//		// config some other Worker
+//		try {
+//			QueueWorker w = (QueueWorker) context
+//					.getBean("mysource2ServerWorker");
+//			AbstractMessageListenerContainer listCont = (AbstractMessageListenerContainer) context
+//					.getBean("mysource2ListenerContainer");
+//			w.setListenerContainer(listCont);
+//		} catch (NoSuchBeanDefinitionException ex) {
+//			LOG.warn("mysource2ServerWorker consumer not declared");
+//		}
+//	}
+
+	private static void configMySourceWorker() {
+		// config Mysource Worker
+		try {
+			QueueWorker w = (QueueWorker) context.getBean("mysourceServerWorker");
+			AbstractMessageListenerContainer listCont = (AbstractMessageListenerContainer) context
+					.getBean("mysourceListenerContainer");
+			w.setListenerContainer(listCont);
+		} catch (NoSuchBeanDefinitionException ex) {
+			LOG.warn("Mysource consumer not declared");
+		}
+	}
+
+}

--- a/applications/hbase-sink-with-trigger-on-finish/server/consumer/src/main/java/org/springframework/integration/samples/server/Controller.java
+++ b/applications/hbase-sink-with-trigger-on-finish/server/consumer/src/main/java/org/springframework/integration/samples/server/Controller.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2002-2010 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.integration.samples.server;
+
+import org.apache.log4j.Logger;
+import org.springframework.context.support.ClassPathXmlApplicationContext;
+
+/**
+ * Server application than can be run as an app or unit test.
+ * 
+ * @author Mark Pollack
+ */
+public class Controller {
+
+	private static Logger LOG = Logger.getLogger(Controller.class);
+	private static ClassPathXmlApplicationContext context;
+
+	public static void main(String[] args) {
+		final String confName = args[0];
+		context = new ClassPathXmlApplicationContext(confName + "-controller/bootstrap-config.xml");
+		LOG.info("Controller for "+confName+" queue isRunning(): "+ context.isRunning());
+	}
+
+}

--- a/applications/hbase-sink-with-trigger-on-finish/server/consumer/src/main/java/org/springframework/integration/samples/server/WorkerConstants.java
+++ b/applications/hbase-sink-with-trigger-on-finish/server/consumer/src/main/java/org/springframework/integration/samples/server/WorkerConstants.java
@@ -1,0 +1,26 @@
+package org.springframework.integration.samples.server;
+
+import org.apache.curator.framework.CuratorFramework;
+import org.apache.curator.framework.CuratorFrameworkFactory;
+import org.apache.curator.retry.ExponentialBackoffRetry;
+
+public class WorkerConstants {
+	// TODO parametrize
+	public static final String CONTROL_RK_SUFFIX = ".control";
+	public static final String RESTART_RK_SUFFIX = ".restart";
+	public static final String PERSISTENT_PATH = "/example";
+	public static final String ZK_CONNECTION_URL = "localhost:2181";
+	public static final int DEFAULT_TIMEOUT = 60;
+	private static final String OUTPUT_TABLE_SUFFIX = "-output";
+	private static final int ZK_BASE_SLEEP_MS = 1000;
+	private static final int ZK_MAX_RETRY = 3;
+	
+	public static CuratorFramework getZkClient() {
+		final ExponentialBackoffRetry retryPolicy = new ExponentialBackoffRetry(ZK_BASE_SLEEP_MS, ZK_MAX_RETRY);
+		return CuratorFrameworkFactory.newClient(WorkerConstants.ZK_CONNECTION_URL, retryPolicy);
+	}
+
+	public static String getOutputTableName(String datapool) {
+		return datapool + WorkerConstants.OUTPUT_TABLE_SUFFIX;
+	}
+}

--- a/applications/hbase-sink-with-trigger-on-finish/server/consumer/src/main/java/org/springframework/integration/samples/server/workers/ControlWorker.java
+++ b/applications/hbase-sink-with-trigger-on-finish/server/consumer/src/main/java/org/springframework/integration/samples/server/workers/ControlWorker.java
@@ -1,0 +1,112 @@
+package org.springframework.integration.samples.server.workers;
+
+import java.io.IOException;
+import java.util.Date;
+
+import org.apache.curator.framework.CuratorFramework;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hbase.HBaseConfiguration;
+import org.apache.hadoop.mapreduce.Job;
+import org.apache.log4j.Logger;
+import org.springframework.amqp.rabbit.core.support.RabbitGatewaySupport;
+import org.springframework.integration.samples.beans.control.RestartMessage;
+import org.springframework.integration.samples.beans.control.StopMessage;
+import org.springframework.integration.samples.hbase.jobs.SampleJob;
+import org.springframework.integration.samples.hbase.utils.HBaseTableUtils;
+import org.springframework.integration.samples.server.WorkerConstants;
+import org.springframework.integration.samples.server.workers.beans.QueueWorkerParams;
+
+public class ControlWorker extends RabbitGatewaySupport {
+
+	private static final Logger LOG = Logger.getLogger(ControlWorker.class);
+	protected final CuratorFramework zKclient;
+	private final QueueWorkerParams params;
+	
+	public ControlWorker(QueueWorkerParams params) {
+		zKclient = WorkerConstants.getZkClient();
+		zKclient.start();
+		this.params = params;
+	}
+
+	public void handleMessage(StopMessage stopMessage) {
+		handleStop(stopMessage);		
+	}
+
+	private synchronized void handleStop(StopMessage stopMessage) {
+		String destQueue = getDestinationQueue(stopMessage.getSource());
+		try {
+			waitForAllConsumersStop(destQueue);
+			handleStopInternal(stopMessage);
+		} catch (Exception e) {
+			LOG.error(e);
+		}
+		LOG.info("HandleStop finished. Send restart message to consumers of "+destQueue);
+		final String rk = destQueue + WorkerConstants.RESTART_RK_SUFFIX;
+		getRabbitTemplate().convertAndSend(rk,new RestartMessage());
+	}
+
+	protected String getDestinationQueue(String datapool) {
+		return datapool;
+	}
+
+	protected void handleStopInternal(StopMessage stopMessage) {
+		LOG.info("All consumers stopped. Starting data transformation (e.g. indexing on Solr or whatever)");
+		long startTimestamp = stopMessage.getTimestamp();
+		final String datapool = stopMessage.getSource();
+		triggerDataTransformation(startTimestamp,datapool);
+	}
+
+	private void waitForAllConsumersStop(String datapool) throws Exception {
+		int timeout = WorkerConstants.DEFAULT_TIMEOUT;
+		//wait until timeout or all consumer detached
+		while (getActiveConsumersCount(datapool)  > 0 || timeout == 0) {
+			timeout--;
+			LOG.info("Active consumers poll timeout: "+timeout);
+			sleep1second();
+		}
+	}
+
+	private int getActiveConsumersCount(String datapool) throws Exception {
+		String persistentPath = WorkerConstants.PERSISTENT_PATH + "/" +datapool;
+		final int count = zKclient.checkExists().forPath(persistentPath).getNumChildren();
+		LOG.info("Active consumers poll: "+count);
+		return count;
+	}
+
+	private void sleep1second() {
+		try {
+			Thread.sleep(1000);
+		} catch (InterruptedException e) {
+			e.printStackTrace();
+		}
+	}
+
+	private void triggerDataTransformation(long startTimestamp, String source) {
+		Date startDate = new Date(startTimestamp);
+		try {
+			final String outputTable = WorkerConstants.getOutputTableName(source);
+			HBaseTableUtils.deleteTable(outputTable);
+			Configuration conf = HBaseConfiguration.create();
+			conf.set("family-column", params.getFamilyColumn());// value
+			conf.set("queue-host", params.getQueueHost());// localhost
+			conf.set("queue-port", params.getQueuePort());// 5672
+			conf.set("queue-adminuser", params.getQueueAdminUser());// guest
+			conf.set("queue-adminpwd", params.getQueueAdminPassword());// guest
+			conf.set("queue-exchange", params.getQueueExchange());
+			Job job = SampleJob.createSampleJob(conf, source,
+					startDate);
+			boolean success = job.waitForCompletion(true);
+			// recompute resuls once finished
+			if (success) {
+				// do whatever you want..could send a message to another queue
+			}
+		} catch (ClassNotFoundException e) {
+			e.printStackTrace();
+		} catch (IOException e) {
+			e.printStackTrace();
+		} catch (InterruptedException e) {
+			e.printStackTrace();
+		}
+	}
+
+}

--- a/applications/hbase-sink-with-trigger-on-finish/server/consumer/src/main/java/org/springframework/integration/samples/server/workers/QueueWorker.java
+++ b/applications/hbase-sink-with-trigger-on-finish/server/consumer/src/main/java/org/springframework/integration/samples/server/workers/QueueWorker.java
@@ -1,0 +1,140 @@
+package org.springframework.integration.samples.server.workers;
+
+import java.io.IOException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import org.apache.curator.framework.CuratorFramework;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hbase.HBaseConfiguration;
+import org.apache.hadoop.hbase.MasterNotRunningException;
+import org.apache.hadoop.hbase.TableNotFoundException;
+import org.apache.hadoop.hbase.ZooKeeperConnectionException;
+import org.apache.hadoop.hbase.client.HBaseAdmin;
+import org.apache.hadoop.hbase.client.HTable;
+import org.apache.hadoop.hbase.client.Put;
+import org.apache.hadoop.hbase.util.Bytes;
+import org.apache.log4j.Logger;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.amqp.rabbit.core.support.RabbitGatewaySupport;
+import org.springframework.amqp.rabbit.listener.AbstractMessageListenerContainer;
+import org.springframework.integration.samples.beans.DocumentToIndex;
+import org.springframework.integration.samples.beans.control.RestartMessage;
+import org.springframework.integration.samples.beans.control.StopMessage;
+import org.springframework.integration.samples.hbase.utils.HBaseTableUtils;
+import org.springframework.integration.samples.managers.QueueFinalizer;
+import org.springframework.integration.samples.server.WorkerConstants;
+import org.springframework.integration.samples.zookeeper.ZkUtils;
+
+public class QueueWorker extends RabbitGatewaySupport{
+
+	private static final Logger LOG = Logger.getLogger(QueueWorker.class);
+	
+	@Getter
+	@Setter
+	protected AbstractMessageListenerContainer listenerContainer;
+
+	protected HTable table;
+	protected String zkNodeName;
+	protected final String source;
+	protected final CuratorFramework zkClient;
+	protected final String familyColumn;
+
+	public QueueWorker(String datapool, String familyColumn) {
+		this(datapool,familyColumn, true);
+			
+		Configuration conf = HBaseConfiguration.create();
+		HBaseAdmin admin = null;
+		try {
+			admin = new HBaseAdmin(conf);
+			final byte[] tableNameBytes = Bytes.toBytes(datapool);
+			try {
+				admin.getTableDescriptor(tableNameBytes);
+			} catch (TableNotFoundException e) {
+				HBaseTableUtils.createTableIfNotExists(datapool,
+						familyColumn, conf);
+			} finally {
+				if (admin != null)
+					try {
+						admin.close();
+					} catch (IOException e) {
+						e.printStackTrace();
+					}
+			}
+
+			table = new HTable(conf, datapool);
+		} catch (MasterNotRunningException e) {
+			e.printStackTrace();
+		} catch (ZooKeeperConnectionException e) {
+			e.printStackTrace();
+		} catch (IOException e) {
+			e.printStackTrace();
+		}
+	}
+
+	protected QueueWorker(String datapool, String familyColumn, boolean simple) {
+		this.source = datapool;
+		this.familyColumn = familyColumn;
+		// Comment to use external Zookeeper instead of embedded
+		zkClient = WorkerConstants.getZkClient();
+		zkClient.start();
+		zkNodeName = ZkUtils.setValueSeq(zkClient, WorkerConstants.PERSISTENT_PATH, datapool); 
+	}
+
+	public void handleMessage(DocumentToIndex doc2index) {
+		boolean stop = doc2index.isStop();
+		if (stop) {
+			//send stop message to topic queue
+			final long startTimestamp = doc2index.getStartTimestamp();
+			final StopMessage stopMsg = new StopMessage();
+			stopMsg.setTimestamp(startTimestamp);
+			stopMsg.setSource(doc2index.getSource().toString());
+			final RabbitTemplate topicRabbitTemplate = getRabbitTemplate();
+			final String rk = source + WorkerConstants.CONTROL_RK_SUFFIX;
+			topicRabbitTemplate.convertAndSend(rk,stopMsg);
+			LOG.debug("STOP Message for [" + doc2index.getRoutingKey() + "] sent to topic exchange");
+			return;
+		}
+
+		handleMessageInternal(doc2index);
+	}
+
+	protected void handleMessageInternal(DocumentToIndex doc2index) {
+		Put put = HBaseTableUtils.getDocToIndexAsPut(doc2index, familyColumn);
+		if (put == null) {
+			LOG.error("Obtained null put for " + doc2index);
+			return;
+		}
+		put(put);
+		LOG.debug("Message for [" + doc2index.getRoutingKey() + "] processed");
+	}
+	public void handleMessage(StopMessage stopMsg){
+		final String zkNodeNameCopy = zkNodeName;
+		zkNodeName = null;
+		ExecutorService executor = Executors.newSingleThreadExecutor();
+		final String persistentPath = WorkerConstants.PERSISTENT_PATH + "/" + source;
+		Runnable worker = new QueueFinalizer(listenerContainer, table ,zkClient, persistentPath, zkNodeNameCopy);
+		executor.execute(worker);
+		executor.shutdown();
+	} 
+	public void handleMessage(RestartMessage restartMsg){
+		if(zkNodeName!=null){
+			LOG.info("Ignore restart message: this node is not waiting for restart ["+zkNodeName+"]");
+			return;
+		}
+		zkNodeName = ZkUtils.setValueSeq(zkClient, WorkerConstants.PERSISTENT_PATH, source);
+		LOG.info("Tell zookeper this node is active again ["+zkNodeName+"]");
+	} 
+
+	private synchronized void put(Put put) {
+		try {
+			table.put(put);
+		} catch (IOException e) {
+			e.printStackTrace();
+		}
+	}
+
+}

--- a/applications/hbase-sink-with-trigger-on-finish/server/consumer/src/main/java/org/springframework/integration/samples/server/workers/beans/QueueWorkerParams.java
+++ b/applications/hbase-sink-with-trigger-on-finish/server/consumer/src/main/java/org/springframework/integration/samples/server/workers/beans/QueueWorkerParams.java
@@ -1,0 +1,16 @@
+package org.springframework.integration.samples.server.workers.beans;
+
+import lombok.Data;
+
+import org.springframework.integration.samples.producer.gateway.HBaseGateway;
+
+@Data
+public class QueueWorkerParams {
+	private HBaseGateway gw;
+	private String familyColumn;
+	private String queueHost;
+	private String queuePort;
+	private String queueAdminUser;
+	private String queueAdminPassword; 
+	private String queueExchange;
+}

--- a/applications/hbase-sink-with-trigger-on-finish/server/consumer/src/main/resources/log4j.properties
+++ b/applications/hbase-sink-with-trigger-on-finish/server/consumer/src/main/resources/log4j.properties
@@ -1,0 +1,19 @@
+log4j.rootCategory=INFO, stdout, file
+
+log4j.appender.stdout=org.apache.log4j.ConsoleAppender
+log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
+
+#log4j.appender.stdout.layout.ConversionPattern=%d %p [%c] - <%m>%n
+log4j.appender.stdout.layout.ConversionPattern=%-5p [%40.40c{4}]: %m%n
+
+log4j.category.org.springframework.amqp.rabbit=INFO
+log4j.category.org.springframework.beans.factory=INFO
+ 
+# Direct log messages to a log file
+log4j.appender.file=org.apache.log4j.RollingFileAppender
+log4j.appender.file.File=/tmp/ens-buffer.log
+log4j.appender.file.MaxFileSize=500MB
+log4j.appender.file.MaxBackupIndex=2
+log4j.appender.file.layout=org.apache.log4j.PatternLayout
+log4j.appender.file.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss} %-5p %c{1}:%L - %m%n
+

--- a/applications/hbase-sink-with-trigger-on-finish/server/consumer/src/main/resources/mysource-consumer/bootstrap-config.xml
+++ b/applications/hbase-sink-with-trigger-on-finish/server/consumer/src/main/resources/mysource-consumer/bootstrap-config.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:context="http://www.springframework.org/schema/context"
+	xmlns:task="http://www.springframework.org/schema/task"
+	xmlns:rabbit="http://www.springframework.org/schema/rabbit"
+	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+		http://www.springframework.org/schema/rabbit http://www.springframework.org/schema/rabbit/spring-rabbit-1.0.xsd
+		http://www.springframework.org/schema/task http://www.springframework.org/schema/task/spring-task-3.0.xsd
+		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.0.xsd">
+
+	<context:property-placeholder location="classpath:sample-buffer.properties"/>
+	
+	<context:property-placeholder system-properties-mode="OVERRIDE"/>
+	
+	<!-- set configuration values -->
+	<context:component-scan base-package="org.springframework.integration.samples.server.workers"/>
+	
+	<rabbit:connection-factory id="connectionFactory"
+		host="${queue.host}" 
+		username="${queue.username}"
+		password="${queue.password}"
+		port="${queue.port}" />
+
+	<bean id="jsonMessageConverter"
+		class="org.springframework.amqp.support.converter.Jackson2JsonMessageConverter" />
+	
+	<rabbit:template id="rabbitTemplate"
+		connection-factory="connectionFactory" 
+		message-converter="jsonMessageConverter"
+		exchange="${test.direct.exchange}" />
+		
+	<rabbit:template id="rabbitTopicTemplate"
+		connection-factory="connectionFactory" 
+		message-converter="jsonMessageConverter"
+		exchange="amq.topic" />
+		
+	<!-- Needed to automatically create queues and exchanges -->
+	<rabbit:admin connection-factory="connectionFactory" />
+	
+	<import resource="classpath:mysource-consumer/queue-exchange-bindings.xml" />
+	<import resource="classpath:mysource-consumer/workers.xml" />
+<!-- 	<import resource="classpath:mysource-consumer/jmx.xml" /> -->
+	
+</beans>

--- a/applications/hbase-sink-with-trigger-on-finish/server/consumer/src/main/resources/mysource-consumer/jmx.xml
+++ b/applications/hbase-sink-with-trigger-on-finish/server/consumer/src/main/resources/mysource-consumer/jmx.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:context="http://www.springframework.org/schema/context"
+	xmlns:p="http://www.springframework.org/schema/p"
+	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.0.xsd">
+
+    <context:mbean-export/>
+
+    <bean id="registry" class="org.springframework.remoting.rmi.RmiRegistryFactoryBean"
+          p:port="1099" />
+    
+    <!-- Expose JMX over RMI -->
+    <bean id="serverConnector" class="org.springframework.jmx.support.ConnectorServerFactoryBean" depends-on="registry"
+          p:objectName="connector:name=rmi"
+          p:serviceUrl="service:jmx:rmi://localhost/jndi/rmi://localhost:1099/myconnector" />
+	
+</beans>

--- a/applications/hbase-sink-with-trigger-on-finish/server/consumer/src/main/resources/mysource-consumer/queue-exchange-bindings.xml
+++ b/applications/hbase-sink-with-trigger-on-finish/server/consumer/src/main/resources/mysource-consumer/queue-exchange-bindings.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:context="http://www.springframework.org/schema/context"
+	xmlns:rabbit="http://www.springframework.org/schema/rabbit"
+	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+		http://www.springframework.org/schema/rabbit http://www.springframework.org/schema/rabbit/spring-rabbit-1.0.xsd
+		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.0.xsd">
+	
+	<rabbit:queue id="mysourceQueue" name="${mysource.queue.name}" durable="true" />
+	<rabbit:queue id="mysourceConsumerQueue" name="${mysource.consumer.queue}" durable="false" />
+	<rabbit:queue id="mysourceControlQueue" name="${mysource.queue.control.name}" durable="false" />
+<!-- 	<rabbit:queue id="myothersourceQueue" name="${myothersource.queue.name}" durable="true" /> -->
+<!-- 	<rabbit:queue id="myothersourceConsumerQueue" name="${myothersource.consumer.queue}" durable="false" /> -->
+<!-- 	<rabbit:queue id="mysotherourceControlQueue" name="${myothersource.queue.control.name}" durable="false" /> -->
+	
+	<rabbit:direct-exchange name="${test.direct.exchange}" >
+		<rabbit:bindings>
+			<rabbit:binding queue="mysourceQueue" key="${mysource.queue.name}" />
+<!-- 			<rabbit:binding queue="myothersourceQueue" key="${myothersource.queue.name}" /> -->
+		</rabbit:bindings>
+	</rabbit:direct-exchange>
+	
+	<rabbit:topic-exchange name="amq.topic" >
+		<rabbit:bindings>
+			<rabbit:binding queue="mysourceConsumerQueue" pattern="${mysource.queue.name}.*" />
+<!-- 			<rabbit:binding queue="myothersourceConsumer1Queue" pattern="${myothersource.queue.name}" /> -->
+		</rabbit:bindings>
+	</rabbit:topic-exchange>
+	
+</beans>

--- a/applications/hbase-sink-with-trigger-on-finish/server/consumer/src/main/resources/mysource-consumer/workers.xml
+++ b/applications/hbase-sink-with-trigger-on-finish/server/consumer/src/main/resources/mysource-consumer/workers.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:rabbit="http://www.springframework.org/schema/rabbit"
+	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+	http://www.springframework.org/schema/rabbit http://www.springframework.org/schema/rabbit/spring-rabbit-1.0.xsd">
+
+	<bean name="mysourceServerWorker" class="org.springframework.integration.samples.server.workers.QueueWorker">
+		<!-- Determine tmp table name -->
+		<constructor-arg index="0">
+			<value>${mysource.queue.name}</value>
+		</constructor-arg>
+		<constructor-arg index="1">
+			<value>value</value>
+		</constructor-arg>
+		<property name="rabbitTemplate" ref="rabbitTopicTemplate" />
+	</bean>
+	
+	<rabbit:listener-container id="mysourceListenerContainer" 
+		concurrency="5" connection-factory="connectionFactory" message-converter="jsonMessageConverter">
+		<rabbit:listener ref="mysourceServerWorker" method="handleMessage" queue-names="#{mysourceQueue.name},#{mysourceConsumerQueue.name}" />
+	</rabbit:listener-container>
+</beans>

--- a/applications/hbase-sink-with-trigger-on-finish/server/consumer/src/main/resources/mysource-controller/bootstrap-config.xml
+++ b/applications/hbase-sink-with-trigger-on-finish/server/consumer/src/main/resources/mysource-controller/bootstrap-config.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:context="http://www.springframework.org/schema/context"
+	xmlns:task="http://www.springframework.org/schema/task"
+	xmlns:rabbit="http://www.springframework.org/schema/rabbit"
+	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+		http://www.springframework.org/schema/rabbit http://www.springframework.org/schema/rabbit/spring-rabbit-1.0.xsd
+		http://www.springframework.org/schema/task http://www.springframework.org/schema/task/spring-task-3.0.xsd
+		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.0.xsd">
+
+	<context:property-placeholder location="classpath:sample-buffer.properties"/>
+	
+	<context:property-placeholder system-properties-mode="OVERRIDE"/>
+	
+	<!-- set configuration values -->
+	<context:component-scan base-package="org.springframework.integration.samples.server.workers"/>
+	
+	<rabbit:connection-factory id="connectionFactory"
+		host="${queue.host}" 
+		username="${queue.username}"
+		password="${queue.password}"
+		port="${queue.port}" />
+
+	<bean id="jsonMessageConverter"
+		class="org.springframework.amqp.support.converter.Jackson2JsonMessageConverter" />
+	
+	<rabbit:template id="rabbitTemplate"
+		connection-factory="connectionFactory" 
+		message-converter="jsonMessageConverter"
+		exchange="${test.direct.exchange}" />
+		
+	<rabbit:template id="rabbitTopicTemplate"
+		connection-factory="connectionFactory" 
+		message-converter="jsonMessageConverter"
+		exchange="amq.topic" />
+		
+	<!-- Needed to automatically create queues and exchanges -->
+	<rabbit:admin connection-factory="connectionFactory" />
+	
+	<import resource="classpath:mysource-controller/queue-exchange-bindings.xml" />
+	<import resource="classpath:mysource-controller/workers.xml" />
+<!-- 	<import resource="classpath:mysource-controller/jmx.xml" /> -->
+	
+</beans>

--- a/applications/hbase-sink-with-trigger-on-finish/server/consumer/src/main/resources/mysource-controller/jmx.xml
+++ b/applications/hbase-sink-with-trigger-on-finish/server/consumer/src/main/resources/mysource-controller/jmx.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:context="http://www.springframework.org/schema/context"
+	xmlns:p="http://www.springframework.org/schema/p"
+	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.0.xsd">
+
+    <context:mbean-export/>
+
+    <bean id="registry" class="org.springframework.remoting.rmi.RmiRegistryFactoryBean"
+          p:port="1099" />
+    
+    <!-- Expose JMX over RMI -->
+    <bean id="serverConnector" class="org.springframework.jmx.support.ConnectorServerFactoryBean" depends-on="registry"
+          p:objectName="connector:name=rmi"
+          p:serviceUrl="service:jmx:rmi://localhost/jndi/rmi://localhost:1099/myconnector" />
+	
+</beans>

--- a/applications/hbase-sink-with-trigger-on-finish/server/consumer/src/main/resources/mysource-controller/queue-exchange-bindings.xml
+++ b/applications/hbase-sink-with-trigger-on-finish/server/consumer/src/main/resources/mysource-controller/queue-exchange-bindings.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:context="http://www.springframework.org/schema/context"
+	xmlns:rabbit="http://www.springframework.org/schema/rabbit"
+	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+		http://www.springframework.org/schema/rabbit http://www.springframework.org/schema/rabbit/spring-rabbit-1.0.xsd
+		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.0.xsd">
+	
+	<rabbit:queue id="mysourceControlQueue" name="${mysource.queue.control.name}" durable="false" />
+	
+	<rabbit:topic-exchange name="amq.topic" >
+		<rabbit:bindings>
+			<rabbit:binding queue="mysourceControlQueue" pattern="${mysource.queue.name}.control" />
+		</rabbit:bindings>
+	</rabbit:topic-exchange>
+	
+</beans>

--- a/applications/hbase-sink-with-trigger-on-finish/server/consumer/src/main/resources/mysource-controller/workers.xml
+++ b/applications/hbase-sink-with-trigger-on-finish/server/consumer/src/main/resources/mysource-controller/workers.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:rabbit="http://www.springframework.org/schema/rabbit"
+	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+	http://www.springframework.org/schema/rabbit http://www.springframework.org/schema/rabbit/spring-rabbit-1.0.xsd">
+
+	<bean id="hbaseGateway" name="hbaseGateway"
+		class="org.springframework.integration.samples.producer.gateway.HBaseGateway">
+		<property name="rabbitTemplate" ref="rabbitTemplate" />
+	</bean>
+	<bean name="queueWorkerParams" class="org.springframework.integration.samples.server.workers.beans.QueueWorkerParams">
+		<property name="gw" ref="hbaseGateway" />
+		<property name="familyColumn">
+			<value>value</value>
+		</property>
+		<property name="queueHost">
+			<value>${queue.host}</value>
+		</property>
+		<property name="queuePort">
+			<value>${queue.port}</value>
+		</property>
+		<property name="queueAdminUser">
+			<value>${queue.username}</value>
+		</property>
+		<property name="queueAdminPassword">
+			<value>${queue.password}</value>
+		</property>
+		<property name="queueExchange">
+			<value>${test.direct.exchange}</value>
+		</property>
+	</bean>
+	<bean name="controlWorker" class="org.springframework.integration.samples.server.workers.ControlWorker">
+		<constructor-arg index="0">
+			<ref bean="queueWorkerParams"/>
+		</constructor-arg>
+		<property name="rabbitTemplate" ref="rabbitTopicTemplate" />
+	</bean>
+	
+	<rabbit:listener-container id="mysourceControlListenerContainer" 
+		concurrency="1" connection-factory="connectionFactory" message-converter="jsonMessageConverter">
+		<rabbit:listener ref="controlWorker" method="handleMessage" queue-names="#{mysourceControlQueue.name}" />
+	</rabbit:listener-container>
+</beans>

--- a/applications/hbase-sink-with-trigger-on-finish/server/consumer/src/main/resources/sample-buffer.properties
+++ b/applications/hbase-sink-with-trigger-on-finish/server/consumer/src/main/resources/sample-buffer.properties
@@ -1,0 +1,16 @@
+queue.host=localhost
+queue.username=guest
+queue.password=guest
+queue.port=5672
+
+# direct exchange name
+test.direct.exchange=test.direct.exchange
+
+mysource.queue.name=mysource
+mysource.queue.control.name=mysource.control
+#someothersource.queue.name=someothersource
+#someothersource.queue.control.name=someothersource.control
+
+# IMPORTANT: assign an unique id to this consumer queue
+mysource.consumer.queue=mysource.consumer.1
+#someothersource.consumer.queue=someothersource.consumer.1

--- a/applications/hbase-sink-with-trigger-on-finish/server/consumer/src/test/java/org/springframework/integration/samples/server/test/EnsController.java
+++ b/applications/hbase-sink-with-trigger-on-finish/server/consumer/src/test/java/org/springframework/integration/samples/server/test/EnsController.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2002-2010 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.integration.samples.server.test;
+
+import org.apache.log4j.Logger;
+import org.springframework.context.support.ClassPathXmlApplicationContext;
+
+/**
+ * Server application than can be run as an app or unit test.
+ * 
+ * @author Mark Pollack
+ */
+public class EnsController {
+
+	private static Logger LOG = Logger.getLogger(EnsController.class);
+	private static ClassPathXmlApplicationContext context;
+
+	public static void main(String[] args) {
+		context = new ClassPathXmlApplicationContext("ens-controller/bootstrap-config.xml");
+		LOG.info("ENS queue controller isRunning(): "+ context.isRunning());
+	}
+
+}

--- a/applications/hbase-sink-with-trigger-on-finish/server/consumer/src/test/java/org/springframework/integration/samples/server/test/EnsQueueConsumer.java
+++ b/applications/hbase-sink-with-trigger-on-finish/server/consumer/src/test/java/org/springframework/integration/samples/server/test/EnsQueueConsumer.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2002-2010 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.integration.samples.server.test;
+
+import org.junit.After;
+import org.junit.Test;
+import org.springframework.amqp.rabbit.listener.AbstractMessageListenerContainer;
+import org.springframework.beans.factory.NoSuchBeanDefinitionException;
+import org.springframework.context.support.ClassPathXmlApplicationContext;
+import org.springframework.integration.samples.server.workers.QueueWorker;
+
+/**
+ * Server application than can be run as an app or unit test.
+ * 
+ * @author Mark Pollack
+ */
+public class EnsQueueConsumer {
+
+	private ClassPathXmlApplicationContext context;
+
+	public static void main(String[] args) {
+		new EnsQueueConsumer().run();
+	}
+
+	@After
+	public void close() {
+		if (context != null) {
+			context.close();
+		}
+	}
+
+	
+
+	@Test
+	public void run() {
+		context = new ClassPathXmlApplicationContext("mysource-consumer/bootstrap-config.xml");
+		configMySourceWorker();
+//		configOtherSourceWorker();
+//		LOG.info("Queue consumer mysource isRunning(): " + context.isRunning());
+	}
+
+
+//	private void configOtherSourceWorker() {
+//		// config some other Worker
+//		try {
+//			QueueWorker w = (QueueWorker) context
+//					.getBean("mysource2ServerWorker");
+//			AbstractMessageListenerContainer listCont = (AbstractMessageListenerContainer) context
+//					.getBean("mysource2ListenerContainer");
+//			w.setListenerContainer(listCont);
+//		} catch (NoSuchBeanDefinitionException ex) {
+//			LOG.warn("mysource2ServerWorker consumer not declared");
+//		}
+//	}
+
+	private void configMySourceWorker() {
+		// config Mysource Worker
+		try {
+			QueueWorker w = (QueueWorker) context.getBean("mysourceServerWorker");
+			AbstractMessageListenerContainer listCont = (AbstractMessageListenerContainer) context
+					.getBean("mysourceListenerContainer");
+			w.setListenerContainer(listCont);
+		} catch (NoSuchBeanDefinitionException ex) {
+//			LOG.warn("Mysource consumer not declared");
+		}
+	}
+
+}

--- a/applications/hbase-sink-with-trigger-on-finish/server/curator/pom.xml
+++ b/applications/hbase-sink-with-trigger-on-finish/server/curator/pom.xml
@@ -1,0 +1,36 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>org.springframework.integration.samples.server</groupId>
+		<artifactId>server</artifactId>
+		<version>2.2.0.BUILD-SNAPSHOT</version>
+	</parent>
+	<artifactId>curator</artifactId>
+	<packaging>jar</packaging>
+	<name>Zookeeper manager</name>
+	<description>Zookeeper manager</description>
+
+	<properties>
+		<curator.version>2.1.0-incubating</curator.version>
+	</properties>
+	<dependencies>
+		<dependency>
+			<groupId>org.apache.curator</groupId>
+			<artifactId>curator-test</artifactId>
+			<version>${curator.version}</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.curator</groupId>
+			<artifactId>curator-recipes</artifactId>
+			<version>${curator.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>log4j</groupId>
+			<artifactId>log4j</artifactId>
+			<version>${log4j.version}</version>
+		</dependency>
+	</dependencies>
+
+</project>

--- a/applications/hbase-sink-with-trigger-on-finish/server/curator/src/main/java/org/springframework/integration/samples/zookeeper/ZkCachedListener.java
+++ b/applications/hbase-sink-with-trigger-on-finish/server/curator/src/main/java/org/springframework/integration/samples/zookeeper/ZkCachedListener.java
@@ -1,0 +1,84 @@
+package org.springframework.integration.samples.zookeeper;
+import org.apache.curator.framework.CuratorFramework;
+import org.apache.curator.framework.recipes.cache.PathChildrenCache;
+import org.apache.curator.framework.recipes.cache.PathChildrenCacheEvent;
+import org.apache.curator.framework.recipes.cache.PathChildrenCacheListener;
+import org.apache.curator.utils.ZKPaths;
+import org.apache.log4j.Logger;
+
+import com.google.common.io.Closeables;
+
+/*
+ * An example of the PathChildrenCache. The example "harness" is a command processor
+ * that allows adding/updating/removed nodes in a path. A PathChildrenCache keeps a
+ * cache of these changes and outputs when updates occurs.
+ */
+public class ZkCachedListener {
+	private static final Logger LOG = Logger.getLogger(ZkCachedListener.class);
+	private final CuratorFramework client;
+	private PathChildrenCache cache;
+	private final String path;
+
+	public ZkCachedListener(CuratorFramework client, String path) {
+		this.client = client;
+		this.path = path;
+	}
+
+	public void startListening() {
+		// in this example we will cache data. Notice that this is optional.
+		cache = new PathChildrenCache(client, path, true);
+		try {
+			cache.start();
+		} catch (Exception e) {
+			e.printStackTrace();
+		}
+		addListener(cache);
+	}
+
+	@SuppressWarnings("deprecation")
+	public void stopListening() {
+		Closeables.closeQuietly(cache);
+		cache = null;
+	}
+
+	private static void addListener(PathChildrenCache cache) {
+		// a PathChildrenCacheListener is optional. Here, it's used just to log
+		// changes
+		PathChildrenCacheListener listener = new PathChildrenCacheListener() {
+			@Override
+			public void childEvent(CuratorFramework client,
+					PathChildrenCacheEvent event) throws Exception {
+				final String eventPath = event.getData().getPath();
+				final String nodeFromPath = ZKPaths.getNodeFromPath(eventPath);
+				switch (event.getType()) {
+					case CHILD_ADDED : {
+						LOG.debug("Node added: " + nodeFromPath);
+						break;
+					}
+
+					case CHILD_UPDATED : {
+						LOG.debug("Node changed: " + nodeFromPath);
+						break;
+					}
+
+					case CHILD_REMOVED : {
+						LOG.debug("Node removed: " + nodeFromPath);
+						break;
+					}
+					case INITIALIZED :
+					default :
+						break;
+				}
+			}
+		};
+		cache.getListenable().addListener(listener);
+	}
+
+	public int getChildrenCount() {
+		if(cache == null)
+			return 0;
+		final int currentSize = cache.getCurrentData().size();
+		return currentSize;
+	}
+
+}

--- a/applications/hbase-sink-with-trigger-on-finish/server/curator/src/main/java/org/springframework/integration/samples/zookeeper/ZkUtils.java
+++ b/applications/hbase-sink-with-trigger-on-finish/server/curator/src/main/java/org/springframework/integration/samples/zookeeper/ZkUtils.java
@@ -1,0 +1,83 @@
+package org.springframework.integration.samples.zookeeper;
+
+import org.apache.curator.framework.CuratorFramework;
+import org.apache.curator.utils.ZKPaths;
+import org.apache.log4j.Logger;
+import org.apache.zookeeper.CreateMode;
+import org.apache.zookeeper.KeeperException;
+import org.apache.zookeeper.data.Stat;
+
+public class ZkUtils {
+	private static final Logger LOG = Logger.getLogger(ZkUtils.class);
+	
+	public static void setValue(CuratorFramework client, String persistentPath, String name, String value){
+
+		if (name.contains("/")) {
+			LOG.error("Invalid node name" + name);
+			return;
+		}
+		String path = ZKPaths.makePath(persistentPath, name);
+
+		try {
+			createPersistenPathIfnotExists(client, persistentPath, path);
+			
+			byte[] bytes = value.getBytes();
+			try {
+				client.setData().forPath(path, bytes);
+			} catch (KeeperException.NoNodeException e) {
+				client.create().creatingParentsIfNeeded().withMode(CreateMode.EPHEMERAL).forPath(path, bytes);
+			}
+		} catch (Exception e) {
+			LOG.error(e);
+		}
+		
+	}
+
+	private static void createPersistenPathIfnotExists(CuratorFramework client,
+			String persistentPath, String path) throws Exception {
+			Stat s = client.checkExists().forPath(persistentPath);
+			if(s==null)
+				client.create().creatingParentsIfNeeded().forPath(path);
+	}
+	
+	public static String setValueSeq(CuratorFramework client, String persistentPath, String suffix, String value){
+
+		if (suffix.contains("/")) {
+			LOG.error("Invalid node name" + suffix);
+			return null;
+		}
+		persistentPath +=  "/" + suffix;
+		String path = ZKPaths.makePath(persistentPath, "zn_") ;
+		String ret = null;
+		try {
+			byte[] bytes = value.getBytes();
+			final CreateMode mode = CreateMode.EPHEMERAL_SEQUENTIAL;
+			ret = client.create().creatingParentsIfNeeded().withMode(mode).forPath(path, bytes);
+			ret = ret.substring(persistentPath.length() + 1);
+		} catch (Exception e) {
+			LOG.error(e);
+		}
+		return ret;
+		
+	}
+	public static String setValueSeq(CuratorFramework client, String persistentPath, String suffix){
+		return setValueSeq(client, persistentPath, suffix,"started");		
+	}
+	
+	public static void remove(CuratorFramework client, String persistentPath, String name) {
+	
+		if (name.contains("/")) {
+			LOG.error("Invalid node name" + name);
+			return;
+		}
+		String path = ZKPaths.makePath(persistentPath, name);
+
+		try {
+			client.delete().forPath(path);
+		} catch (KeeperException.NoNodeException e) {
+			// ignore
+		} catch (Exception e) {
+			LOG.error(e);
+		}
+	}
+}

--- a/applications/hbase-sink-with-trigger-on-finish/server/curator/src/main/resources/log4j.properties
+++ b/applications/hbase-sink-with-trigger-on-finish/server/curator/src/main/resources/log4j.properties
@@ -1,0 +1,10 @@
+log4j.rootCategory=INFO, stdout
+
+log4j.appender.stdout=org.apache.log4j.ConsoleAppender
+log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
+
+#log4j.appender.stdout.layout.ConversionPattern=%d %p [%c] - <%m>%n
+log4j.appender.stdout.layout.ConversionPattern=%-5p [%40.40c{4}]: %m%n
+
+log4j.category.org.springframework.amqp.rabbit=INFO
+log4j.category.org.springframework.beans.factory=INFO

--- a/applications/hbase-sink-with-trigger-on-finish/server/curator/src/test/java/org/springframework/integration/samples/test/zookeeper/ParentChildTest.java
+++ b/applications/hbase-sink-with-trigger-on-finish/server/curator/src/test/java/org/springframework/integration/samples/test/zookeeper/ParentChildTest.java
@@ -1,0 +1,197 @@
+package org.springframework.integration.samples.test.zookeeper;
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.util.Arrays;
+
+import org.apache.curator.framework.CuratorFramework;
+import org.apache.curator.framework.CuratorFrameworkFactory;
+import org.apache.curator.framework.recipes.cache.ChildData;
+import org.apache.curator.framework.recipes.cache.PathChildrenCache;
+import org.apache.curator.framework.recipes.cache.PathChildrenCacheEvent;
+import org.apache.curator.framework.recipes.cache.PathChildrenCacheListener;
+import org.apache.curator.retry.ExponentialBackoffRetry;
+import org.apache.curator.utils.ZKPaths;
+import org.apache.zookeeper.CreateMode;
+import org.apache.zookeeper.KeeperException;
+
+import com.google.common.io.Closeables;
+
+/*
+ * An example of the PathChildrenCache. The example "harness" is a command processor
+ * that allows adding/updating/removed nodes in a path. A PathChildrenCache keeps a
+ * cache of these changes and outputs when updates occurs.
+ */
+public class ParentChildTest {
+	private static final String PATH = "/example/cache";
+	private static final String CONNECTION_URL = "localhost:2181";
+
+	@SuppressWarnings("deprecation")
+	public static void main(String[] args) throws Exception {
+		CuratorFramework client = null;
+		PathChildrenCache cache = null;
+		try {
+			client = CuratorFrameworkFactory.newClient(CONNECTION_URL, 
+					new ExponentialBackoffRetry(1000, 3));
+			client.start();
+
+			// in this example we will cache data. Notice that this is optional.
+			cache = new PathChildrenCache(client, PATH, true);
+			cache.start();
+
+
+			addListener(cache);
+			
+			processCommands(client, cache);
+		} finally {
+			Closeables.closeQuietly(cache);
+			Closeables.closeQuietly(client);
+		}
+	}
+
+	private static void addListener(PathChildrenCache cache) {
+		// a PathChildrenCacheListener is optional. Here, it's used just to log
+		// changes
+		PathChildrenCacheListener listener = new PathChildrenCacheListener() {
+			@Override
+			public void childEvent(CuratorFramework client,
+					PathChildrenCacheEvent event) throws Exception {
+				switch (event.getType()) {
+					case CHILD_ADDED : {
+						System.out.println("Node added: "
+								+ ZKPaths.getNodeFromPath(event.getData()
+										.getPath()));
+						break;
+					}
+
+					case CHILD_UPDATED : {
+						System.out.println("Node changed: "
+								+ ZKPaths.getNodeFromPath(event.getData()
+										.getPath()));
+						break;
+					}
+
+					case CHILD_REMOVED : {
+						System.out.println("Node removed: "
+								+ ZKPaths.getNodeFromPath(event.getData()
+										.getPath()));
+						break;
+					}
+					case INITIALIZED:
+					default: break;
+				}
+			}
+		};
+		cache.getListenable().addListener(listener);
+	}
+
+	private static void processCommands(CuratorFramework client,
+			PathChildrenCache cache) throws Exception {
+		// More scaffolding that does a simple command line processor
+
+		printHelp();
+
+		BufferedReader in = new BufferedReader(new InputStreamReader(System.in));
+		boolean done = false;
+		while (!done) {
+			System.out.print("> ");
+
+			String command = in.readLine().trim();
+			String[] parts = command.split("\\s");
+			if (parts.length == 0) {
+				continue;
+			}
+			String operation = parts[0];
+			String args[] = Arrays.copyOfRange(parts, 1, parts.length);
+
+			if (operation.equalsIgnoreCase("help")
+					|| operation.equalsIgnoreCase("?")) {
+				printHelp();
+			} else if (operation.equalsIgnoreCase("q")
+					|| operation.equalsIgnoreCase("quit")) {
+				done = true;
+			} else if (operation.equals("set")) {
+				setValue(client, command, args);
+			} else if (operation.equals("refresh")) {
+				cache.rebuild();
+			} else if (operation.equals("remove")) {
+				remove(client, command, args);
+			} else if (operation.equals("list")) {
+				list(cache);
+			}
+
+			Thread.sleep(1000); // just to allow the console output to catch up
+		}
+
+	}
+
+	private static void list(PathChildrenCache cache) {
+		final int currentSize = cache.getCurrentData().size();
+		if (currentSize == 0) {
+			System.out.println("* empty *");
+		} else {
+			System.out.println("Found "+currentSize+" zNodes");
+			for (ChildData data : cache.getCurrentData()) {
+				System.out.println(data.getPath() + " = "
+						+ new String(data.getData()));
+			}
+		}
+	}
+
+	private static void remove(CuratorFramework client, String command,
+			String[] args) throws Exception {
+		if (args.length != 1) {
+			System.err.println("syntax error (expected remove <path>): "
+					+ command);
+			return;
+		}
+
+		String name = args[0];
+		if (name.contains("/")) {
+			System.err.println("Invalid node name" + name);
+			return;
+		}
+		String path = ZKPaths.makePath(PATH, name);
+
+		try {
+			client.delete().forPath(path);
+		} catch (KeeperException.NoNodeException e) {
+			// ignore
+		}
+	}
+
+	private static void setValue(CuratorFramework client, String command,
+			String[] args) throws Exception {
+		if (args.length != 2) {
+			System.err.println("syntax error (expected set <path> <value>): "
+					+ command);
+			return;
+		}
+
+		String name = args[0];
+		if (name.contains("/")) {
+			System.err.println("Invalid node name" + name);
+			return;
+		}
+		String path = ZKPaths.makePath(PATH, name);
+
+		byte[] bytes = args[1].getBytes();
+		try {
+			client.setData().forPath(path, bytes);
+		} catch (KeeperException.NoNodeException e) {
+			client.create().creatingParentsIfNeeded().withMode(CreateMode.EPHEMERAL).forPath(path, bytes);
+		}
+	}
+
+	private static void printHelp() {
+		System.out
+				.println("An example of using PathChildrenCache. This example is driven by entering commands at the prompt:\n");
+		System.out
+				.println("set <name> <value>: Adds or updates a node with the given name");
+		System.out
+				.println("remove <name>: Deletes the node with the given name");
+		System.out.println("delete: List the nodes/values in the cache");
+		System.out.println("refresh: Refresh the cache");
+		System.out.println("quit: Quit the example");
+		System.out.println();
+	}
+}

--- a/applications/hbase-sink-with-trigger-on-finish/server/curator/src/test/java/org/springframework/integration/samples/test/zookeeper/SimpleCuratorTests.java
+++ b/applications/hbase-sink-with-trigger-on-finish/server/curator/src/test/java/org/springframework/integration/samples/test/zookeeper/SimpleCuratorTests.java
@@ -1,0 +1,184 @@
+package org.springframework.integration.samples.test.zookeeper;
+import java.util.List;
+
+import org.apache.curator.RetryPolicy;
+import org.apache.curator.framework.CuratorFramework;
+import org.apache.curator.framework.CuratorFrameworkFactory;
+import org.apache.curator.framework.api.BackgroundCallback;
+import org.apache.curator.framework.api.CuratorEvent;
+import org.apache.curator.framework.api.CuratorListener;
+import org.apache.curator.retry.ExponentialBackoffRetry;
+import org.apache.zookeeper.CreateMode;
+import org.apache.zookeeper.WatchedEvent;
+import org.apache.zookeeper.Watcher;
+
+public class SimpleCuratorTests {
+
+	public static CuratorFramework createSimple(String connectionString) {
+		// these are reasonable arguments for the ExponentialBackoffRetry. The
+		// first
+		// retry will wait 1 second - the second will wait up to 2 seconds - the
+		// third will wait up to 4 seconds.
+		ExponentialBackoffRetry retryPolicy = new ExponentialBackoffRetry(1000,
+				3);
+
+		// The simplest way to get a CuratorFramework instance. This will use
+		// default values.
+		// The only required arguments are the connection string and the retry
+		// policy
+		return CuratorFrameworkFactory.newClient(connectionString, retryPolicy);
+	}
+
+	public static CuratorFramework createWithOptions(String connectionString,
+			RetryPolicy retryPolicy, int connectionTimeoutMs,
+			int sessionTimeoutMs) {
+		// using the CuratorFrameworkFactory.builder() gives fine grained
+		// control
+		// over creation options. See the CuratorFrameworkFactory.Builder
+		// javadoc
+		// details
+		return CuratorFrameworkFactory.builder()
+				.connectString(connectionString).retryPolicy(retryPolicy)
+				.connectionTimeoutMs(connectionTimeoutMs)
+				.sessionTimeoutMs(sessionTimeoutMs)
+				// etc. etc.
+				.build();
+	}
+
+	public static void create(CuratorFramework client, String path,
+			byte[] payload) throws Exception {
+		// this will create the given ZNode with the given data
+		client.create().forPath(path, payload);
+	}
+
+	public static void createEphemeral(CuratorFramework client, String path,
+			byte[] payload) throws Exception {
+		// this will create the given EPHEMERAL ZNode with the given data
+		client.create().withMode(CreateMode.EPHEMERAL).forPath(path, payload);
+	}
+
+	public static String createEphemeralSequential(CuratorFramework client,
+			String path, byte[] payload) throws Exception {
+		// this will create the given EPHEMERAL-SEQUENTIAL ZNode with the given
+		// data using Curator protection.
+
+		/*
+		 * Protection Mode:
+		 * 
+		 * It turns out there is an edge case that exists when creating
+		 * sequential-ephemeral nodes. The creation can succeed on the server,
+		 * but the server can crash before the created node name is returned to
+		 * the client. However, the ZK session is still valid so the ephemeral
+		 * node is not deleted. Thus, there is no way for the client to
+		 * determine what node was created for them.
+		 * 
+		 * Even without sequential-ephemeral, however, the create can succeed on
+		 * the sever but the client (for various reasons) will not know it.
+		 * Putting the create builder into protection mode works around this.
+		 * The name of the node that is created is prefixed with a GUID. If node
+		 * creation fails the normal retry mechanism will occur. On the retry,
+		 * the parent path is first searched for a node that has the GUID in it.
+		 * If that node is found, it is assumed to be the lost node that was
+		 * successfully created on the first try and is returned to the caller.
+		 */
+		return client.create().withProtection()
+				.withMode(CreateMode.EPHEMERAL_SEQUENTIAL)
+				.forPath(path, payload);
+	}
+
+	public static void setData(CuratorFramework client, String path,
+			byte[] payload) throws Exception {
+		// set data for the given node
+		client.setData().forPath(path, payload);
+	}
+
+	public static void setDataAsyncWithCallback(CuratorFramework client,
+			BackgroundCallback callback, String path, byte[] payload)
+			throws Exception {
+		// this is another method of getting notification of an async completion
+		client.setData().inBackground(callback).forPath(path, payload);
+	}
+
+	public static void delete(CuratorFramework client, String path)
+			throws Exception {
+		// delete the given node
+		client.delete().forPath(path);
+	}
+
+	public static void guaranteedDelete(CuratorFramework client, String path)
+			throws Exception {
+		// delete the given node and guarantee that it completes
+
+		/*
+		 * Guaranteed Delete
+		 * 
+		 * Solves this edge case: deleting a node can fail due to connection
+		 * issues. Further, if the node was ephemeral, the node will not get
+		 * auto-deleted as the session is still valid. This can wreak havoc with
+		 * lock implementations.
+		 * 
+		 * 
+		 * When guaranteed is set, Curator will record failed node deletions and
+		 * attempt to delete them in the background until successful. NOTE: you
+		 * will still get an exception when the deletion fails. But, you can be
+		 * assured that as long as the CuratorFramework instance is open
+		 * attempts will be made to delete the node.
+		 */
+
+		client.delete().guaranteed().forPath(path);
+	}
+
+	public static List<String> watchedGetChildren(CuratorFramework client,
+			String path) throws Exception {
+		/**
+		 * Get children and set a watcher on the node. The watcher notification
+		 * will come through the CuratorListener (see setDataAsync() above).
+		 */
+		return client.getChildren().watched().forPath(path);
+	}
+
+	public static List<String> watchedGetChildren(CuratorFramework client,
+			String path, Watcher watcher) throws Exception {
+		/**
+		 * Get children and set the given watcher on the node.
+		 */
+		return client.getChildren().usingWatcher(watcher).forPath(path);
+	}
+	public static void main(String[] args) throws Exception {
+		CuratorFramework client = createSimple("localhost:2181");
+		client.start();
+		
+		final String path = "/zkEphemeral";
+		createEphemeral(client, path, "sometest1".getBytes());
+		
+		watchedGetChildren(client, path);
+		CuratorListener     localListener = new CuratorListener() {
+			
+			public void eventReceived(CuratorFramework client, CuratorEvent event)
+					throws Exception {
+				// TODO Auto-generated method stub
+				if ( event.getWatchedEvent() != null )
+				{
+					System.out.println("Watched! " + event);
+				}
+				
+			}
+		};
+        client.getCuratorListenable().addListener(localListener);
+	
+        
+        
+        
+		Watcher watcher = new Watcher() {
+			
+			public void process(WatchedEvent event) {
+				System.out.println("Watched! "+ event);
+				
+			}
+		};
+		watchedGetChildren(client, path,watcher);
+		delete(client, path);
+		System.out.println("Done!");
+		
+	}
+}

--- a/applications/hbase-sink-with-trigger-on-finish/server/curator/src/test/java/org/springframework/integration/samples/test/zookeeper/TestZkCachedListener.java
+++ b/applications/hbase-sink-with-trigger-on-finish/server/curator/src/test/java/org/springframework/integration/samples/test/zookeeper/TestZkCachedListener.java
@@ -1,0 +1,106 @@
+package org.springframework.integration.samples.test.zookeeper;
+
+import org.apache.curator.framework.CuratorFramework;
+import org.apache.curator.framework.CuratorFrameworkFactory;
+import org.apache.curator.retry.ExponentialBackoffRetry;
+import org.apache.curator.test.TestingServer;
+import org.apache.log4j.Logger;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.integration.samples.zookeeper.ZkCachedListener;
+import org.springframework.integration.samples.zookeeper.ZkUtils;
+
+import com.google.common.io.Closeables;
+
+public class TestZkCachedListener {
+	
+	private static final Logger LOG = Logger.getLogger(TestZkCachedListener.class);
+	private static final int ZK_PORT = 2181;
+	private static final String CONNECTION_URL = "localhost:"+ZK_PORT;
+	private static final String PERSISTENT_PATH = "/example/cache";
+	private CuratorFramework client;
+	private TestingServer server;
+
+	@Before
+	public void init() throws Exception {
+		// create temporary zookeeper dir in /tmp on port 2281
+		server = new TestingServer(ZK_PORT);
+		final int maxRetries = 3;
+		final int baseSleepTimeMs = 1000;
+		String connectionUrl = CONNECTION_URL;
+		// Comment to use external Zookeeper instead of embedded
+		connectionUrl = server.getConnectString();
+		client = CuratorFrameworkFactory.newClient(connectionUrl, 
+				new ExponentialBackoffRetry(baseSleepTimeMs, maxRetries));
+		client.start();
+	}
+	
+	@Override
+	@SuppressWarnings("deprecation")
+	@After
+	public void finalize() throws Exception {
+		if (server!=null)
+			Closeables.closeQuietly(server);
+	}
+	
+	
+	@SuppressWarnings("deprecation")
+	@Test
+	public void test() throws InterruptedException {
+		final ZkCachedListener l = new ZkCachedListener(client, PERSISTENT_PATH);
+		l.startListening();
+		ZkUtils.setValue(client, PERSISTENT_PATH, "zNode1", "somevalue");
+		
+		//get count immediately and 5 secs after stop
+		getActiveNodesCount(l);
+		l.stopListening();
+		Thread.sleep(5 * 1000);
+		getActiveNodesCount(l);
+
+		Closeables.closeQuietly(client);
+		
+	}
+
+	private void getActiveNodesCount(final ZkCachedListener l) throws InterruptedException {
+		Thread.sleep(1 * 1000);
+		int count = l.getChildrenCount();
+		LOG.info("Found "+count+" active zNodes");
+	}
+	private void getActiveNodesCount(String path) throws Exception {
+		Thread.sleep(1 * 1000);
+		int count =client.getChildren().forPath(path).size();
+		LOG.info("Found "+count+" active zNodes");
+	}
+	
+	@SuppressWarnings("deprecation")
+	@Test
+	public void testAddAndRemoveNode() throws Exception {
+		ZkUtils.setValue(client, PERSISTENT_PATH, "zNode1", "somevalue");
+		getActiveNodesCount(PERSISTENT_PATH);
+		
+		ZkUtils.remove(client, PERSISTENT_PATH, "zNode1");
+		
+		Thread.sleep(5 * 1000);
+		getActiveNodesCount(PERSISTENT_PATH);
+		
+		Closeables.closeQuietly(client);
+		
+	}
+	
+	@SuppressWarnings("deprecation")
+	@Test
+	public void testAddAndRemoveNodeSeq() throws Exception {
+		String nodeName = ZkUtils.setValueSeq(client, PERSISTENT_PATH, "zNode1", "somevalue");
+		getActiveNodesCount(PERSISTENT_PATH);
+		
+		ZkUtils.remove(client, PERSISTENT_PATH + "/zNode1",  nodeName);
+		
+		Thread.sleep(5 * 1000);
+		getActiveNodesCount(PERSISTENT_PATH);
+		
+		Closeables.closeQuietly(client);
+		
+	}
+	
+}

--- a/applications/hbase-sink-with-trigger-on-finish/server/persistence/conf/localhost/hbase-default.xml
+++ b/applications/hbase-sink-with-trigger-on-finish/server/persistence/conf/localhost/hbase-default.xml
@@ -1,0 +1,952 @@
+<?xml version="1.0"?>
+<?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
+<!--
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+-->
+<configuration>
+  <property>
+    <name>hbase.rootdir</name>
+    <value>file:///tmp/hbase-${user.name}/hbase</value>
+    <description>The directory shared by region servers and into
+    which HBase persists.  The URL should be 'fully-qualified'
+    to include the filesystem scheme.  For example, to specify the
+    HDFS directory '/hbase' where the HDFS instance's namenode is
+    running at namenode.example.org on port 9000, set this value to:
+    hdfs://namenode.example.org:9000/hbase.  By default HBase writes
+    into /tmp.  Change this configuration else all data will be lost
+    on machine restart.
+    </description>
+  </property>
+  <property>
+    <name>hbase.master.port</name>
+    <value>60000</value>
+    <description>The port the HBase Master should bind to.</description>
+  </property>
+  <property>
+    <name>hbase.cluster.distributed</name>
+    <value>false</value>
+    <description>The mode the cluster will be in. Possible values are
+      false for standalone mode and true for distributed mode.  If
+      false, startup will run all HBase and ZooKeeper daemons together
+      in the one JVM.
+    </description>
+  </property>
+  <property>
+    <name>hbase.tmp.dir</name>
+    <value>${java.io.tmpdir}/hbase-${user.name}</value>
+    <description>Temporary directory on the local filesystem.
+    Change this setting to point to a location more permanent
+    than '/tmp' (The '/tmp' directory is often cleared on
+    machine restart).
+    </description>
+  </property>
+  <property>
+    <name>hbase.local.dir</name>
+    <value>${hbase.tmp.dir}/local/</value>
+    <description>Directory on the local filesystem to be used 
+    as a local storage.
+    </description>
+  </property>
+  <property>
+    <name>hbase.master.info.port</name>
+    <value>60010</value>
+    <description>The port for the HBase Master web UI.
+    Set to -1 if you do not want a UI instance run.
+    </description>
+  </property>
+  <property>
+    <name>hbase.master.info.bindAddress</name>
+    <value>0.0.0.0</value>
+    <description>The bind address for the HBase Master web UI
+    </description>
+  </property>
+  <property>
+    <name>hbase.client.write.buffer</name>
+    <value>2097152</value>
+    <description>Default size of the HTable clien write buffer in bytes.
+    A bigger buffer takes more memory -- on both the client and server
+    side since server instantiates the passed write buffer to process
+    it -- but a larger buffer size reduces the number of RPCs made.
+    For an estimate of server-side memory-used, evaluate
+    hbase.client.write.buffer * hbase.regionserver.handler.count
+    </description>
+  </property>
+  <property>
+    <name>hbase.regionserver.port</name>
+    <value>60020</value>
+    <description>The port the HBase RegionServer binds to.
+    </description>
+  </property>
+  <property>
+    <name>hbase.regionserver.info.port</name>
+    <value>60030</value>
+    <description>The port for the HBase RegionServer web UI
+    Set to -1 if you do not want the RegionServer UI to run.
+    </description>
+  </property>
+  <property>
+    <name>hbase.regionserver.info.port.auto</name>
+    <value>false</value>
+    <description>Whether or not the Master or RegionServer
+    UI should search for a port to bind to. Enables automatic port
+    search if hbase.regionserver.info.port is already in use.
+    Useful for testing, turned off by default.
+    </description>
+  </property>
+  <property>
+    <name>hbase.regionserver.info.bindAddress</name>
+    <value>0.0.0.0</value>
+    <description>The address for the HBase RegionServer web UI
+    </description>
+  </property>
+  <property>
+    <name>hbase.regionserver.class</name>
+    <value>org.apache.hadoop.hbase.ipc.HRegionInterface</value>
+    <description>The RegionServer interface to use.
+    Used by the client opening proxy to remote region server.
+    </description>
+  </property>
+  <property>
+    <name>hbase.client.pause</name>
+    <value>1000</value>
+    <description>General client pause value.  Used mostly as value to wait
+    before running a retry of a failed get, region lookup, etc.</description>
+  </property>
+  <property>
+    <name>hbase.client.retries.number</name>
+    <value>10</value>
+    <description>Maximum retries.  Used as maximum for all retryable
+    operations such as fetching of the root region from root region
+    server, getting a cell's value, starting a row update, etc.
+    Default: 10.
+    </description>
+  </property> 
+  <property>
+    <name>hbase.bulkload.retries.number</name>
+    <value>0</value>
+    <description>Maximum retries.  This is maximum number of iterations
+    to atomic bulk loads are attempted in the face of splitting operations
+    0 means never give up.  Default: 0.
+    </description>
+  </property>
+  <property>
+    <name>hbase.client.scanner.caching</name>
+    <value>1</value>
+    <description>Number of rows that will be fetched when calling next
+    on a scanner if it is not served from (local, client) memory. Higher
+    caching values will enable faster scanners but will eat up more memory
+    and some calls of next may take longer and longer times when the cache is empty.
+    Do not set this value such that the time between invocations is greater
+    than the scanner timeout; i.e. hbase.regionserver.lease.period
+    </description>
+  </property>
+  <property>
+    <name>hbase.client.keyvalue.maxsize</name>
+    <value>10485760</value>
+    <description>Specifies the combined maximum allowed size of a KeyValue
+    instance. This is to set an upper boundary for a single entry saved in a
+    storage file. Since they cannot be split it helps avoiding that a region
+    cannot be split any further because the data is too large. It seems wise
+    to set this to a fraction of the maximum region size. Setting it to zero
+    or less disables the check.
+    </description>
+  </property>
+  <property>
+    <name>hbase.regionserver.lease.period</name>
+    <value>60000</value>
+    <description>HRegion server lease period in milliseconds. Default is
+    60 seconds. Clients must report in within this period else they are
+    considered dead.</description>
+  </property>
+  <property>
+    <name>hbase.regionserver.handler.count</name>
+    <value>10</value>
+    <description>Count of RPC Listener instances spun up on RegionServers.
+    Same property is used by the Master for count of master handlers.
+    Default is 10.
+    </description>
+  </property>
+  <property>
+    <name>hbase.regionserver.msginterval</name>
+    <value>3000</value>
+    <description>Interval between messages from the RegionServer to Master
+    in milliseconds.
+    </description>
+  </property>
+  <property>
+    <name>hbase.regionserver.optionallogflushinterval</name>
+    <value>1000</value>
+    <description>Sync the HLog to the HDFS after this interval if it has not
+    accumulated enough entries to trigger a sync. Default 1 second. Units:
+    milliseconds.
+    </description>
+  </property>
+  <property>
+    <name>hbase.regionserver.regionSplitLimit</name>
+    <value>2147483647</value>
+    <description>Limit for the number of regions after which no more region
+    splitting should take place. This is not a hard limit for the number of
+    regions but acts as a guideline for the regionserver to stop splitting after
+    a certain limit. Default is set to MAX_INT; i.e. do not block splitting.
+    </description>
+  </property>
+  <property>
+    <name>hbase.regionserver.logroll.period</name>
+    <value>3600000</value>
+    <description>Period at which we will roll the commit log regardless
+    of how many edits it has.</description>
+  </property>
+  <property>
+    <name>hbase.regionserver.logroll.errors.tolerated</name>
+    <value>2</value>
+    <description>The number of consecutive WAL close errors we will allow
+    before triggering a server abort.  A setting of 0 will cause the
+    region server to abort if closing the current WAL writer fails during
+    log rolling.  Even a small value (2 or 3) will allow a region server
+    to ride over transient HDFS errors.</description>
+  </property>
+  <property>
+    <name>hbase.regionserver.hlog.reader.impl</name>
+    <value>org.apache.hadoop.hbase.regionserver.wal.SequenceFileLogReader</value>
+    <description>The HLog file reader implementation.</description>
+  </property>
+  <property>
+    <name>hbase.regionserver.hlog.writer.impl</name>
+    <value>org.apache.hadoop.hbase.regionserver.wal.SequenceFileLogWriter</value>
+    <description>The HLog file writer implementation.</description>
+  </property>
+  <property>
+    <name>hbase.regionserver.separate.hlog.for.meta</name>
+    <value>false</value>
+  </property>
+  <property>
+    <name>hbase.regionserver.nbreservationblocks</name>
+    <value>4</value>
+    <description>The number of resevoir blocks of memory release on
+    OOME so we can cleanup properly before server shutdown.
+    </description>
+  </property>
+  <property>
+    <name>hbase.zookeeper.dns.interface</name>
+    <value>default</value>
+    <description>The name of the Network Interface from which a ZooKeeper server
+      should report its IP address.
+    </description>
+  </property>
+  <property>
+    <name>hbase.zookeeper.dns.nameserver</name>
+    <value>default</value>
+    <description>The host name or IP address of the name server (DNS)
+      which a ZooKeeper server should use to determine the host name used by the
+      master for communication and display purposes.
+    </description>
+  </property>
+  <property>
+    <name>hbase.regionserver.dns.interface</name>
+    <value>default</value>
+    <description>The name of the Network Interface from which a region server
+      should report its IP address.
+    </description>
+  </property>
+  <property>
+    <name>hbase.regionserver.dns.nameserver</name>
+    <value>default</value>
+    <description>The host name or IP address of the name server (DNS)
+      which a region server should use to determine the host name used by the
+      master for communication and display purposes.
+    </description>
+  </property>
+  <property>
+    <name>hbase.master.dns.interface</name>
+    <value>default</value>
+    <description>The name of the Network Interface from which a master
+      should report its IP address.
+    </description>
+  </property>
+  <property>
+    <name>hbase.master.dns.nameserver</name>
+    <value>default</value>
+    <description>The host name or IP address of the name server (DNS)
+      which a master should use to determine the host name used
+      for communication and display purposes.
+    </description>
+  </property>
+  <property>
+    <name>hbase.balancer.period
+    </name>
+    <value>300000</value>
+    <description>Period at which the region balancer runs in the Master.
+    </description>
+  </property>
+  <property>
+    <name>hbase.regions.slop</name>
+    <value>0.2</value>
+    <description>Rebalance if any regionserver has average + (average * slop) regions.
+    Default is 20% slop.
+    </description>
+  </property>
+  <property>
+    <name>hbase.master.logcleaner.ttl</name>
+    <value>600000</value>
+    <description>Maximum time a HLog can stay in the .oldlogdir directory,
+    after which it will be cleaned by a Master thread.
+    </description>
+  </property>
+  <property>
+    <name>hbase.master.logcleaner.plugins</name>
+    <value>org.apache.hadoop.hbase.master.cleaner.TimeToLiveLogCleaner</value>
+    <description>A comma-separated list of LogCleanerDelegate invoked by
+    the LogsCleaner service. These WAL/HLog cleaners are called in order,
+    so put the HLog cleaner that prunes the most HLog files in front. To
+    implement your own LogCleanerDelegate, just put it in HBase's classpath
+    and add the fully qualified class name here. Always add the above
+    default log cleaners in the list.
+    </description>
+  </property>
+  <property>
+    <name>hbase.regionserver.global.memstore.upperLimit</name>
+    <value>0.4</value>
+    <description>Maximum size of all memstores in a region server before new
+      updates are blocked and flushes are forced. Defaults to 40% of heap
+    </description>
+  </property>
+  <property>
+    <name>hbase.regionserver.global.memstore.lowerLimit</name>
+    <value>0.35</value>
+    <description>When memstores are being forced to flush to make room in
+      memory, keep flushing until we hit this mark. Defaults to 35% of heap.
+      This value equal to hbase.regionserver.global.memstore.upperLimit causes
+      the minimum possible flushing to occur when updates are blocked due to
+      memstore limiting.
+    </description>
+  </property>
+  <property>
+    <name>hbase.server.thread.wakefrequency</name>
+    <value>10000</value>
+    <description>Time to sleep in between searches for work (in milliseconds).
+    Used as sleep interval by service threads such as log roller.
+    </description>
+  </property>
+  <property>
+    <name>hbase.server.versionfile.writeattempts</name>
+    <value>3</value>
+    <description>
+    How many time to retry attempting to write a version file
+    before just aborting. Each attempt is seperated by the
+    hbase.server.thread.wakefrequency milliseconds.
+    </description>
+  </property>
+  <property>
+    <name>hbase.regionserver.optionalcacheflushinterval</name>
+    <value>3600000</value>
+    <description>
+    Maximum amount of time an edit lives in memory before being automatically flushed.
+    Default 1 hour. Set it to 0 to disable automatic flushing.
+    </description>
+  </property>
+  <property>
+    <name>hbase.hregion.memstore.flush.size</name>
+    <value>134217728</value>
+    <description>
+    Memstore will be flushed to disk if size of the memstore
+    exceeds this number of bytes.  Value is checked by a thread that runs
+    every hbase.server.thread.wakefrequency.
+    </description>
+  </property>
+  <property>
+    <name>hbase.hregion.preclose.flush.size</name>
+    <value>5242880</value>
+    <description>
+      If the memstores in a region are this size or larger when we go
+      to close, run a "pre-flush" to clear out memstores before we put up
+      the region closed flag and take the region offline.  On close,
+      a flush is run under the close flag to empty memory.  During
+      this time the region is offline and we are not taking on any writes.
+      If the memstore content is large, this flush could take a long time to
+      complete.  The preflush is meant to clean out the bulk of the memstore
+      before putting up the close flag and taking the region offline so the
+      flush that runs under the close flag has little to do.
+    </description>
+  </property>
+  <property>
+    <name>hbase.hregion.memstore.block.multiplier</name>
+    <value>2</value>
+    <description>
+    Block updates if memstore has hbase.hregion.block.memstore
+    time hbase.hregion.flush.size bytes.  Useful preventing
+    runaway memstore during spikes in update traffic.  Without an
+    upper-bound, memstore fills such that when it flushes the
+    resultant flush files take a long time to compact or split, or
+    worse, we OOME.
+    </description>
+  </property>
+  <property>
+    <name>hbase.hregion.memstore.mslab.enabled</name>
+    <value>true</value>
+    <description>
+      Enables the MemStore-Local Allocation Buffer,
+      a feature which works to prevent heap fragmentation under
+      heavy write loads. This can reduce the frequency of stop-the-world
+      GC pauses on large heaps.
+    </description>
+  </property>
+  <property>
+    <name>hbase.hregion.max.filesize</name>
+    <value>10737418240</value>
+    <description>
+    Maximum HStoreFile size. If any one of a column families' HStoreFiles has
+    grown to exceed this value, the hosting HRegion is split in two.
+    Default: 10G.
+    </description>
+  </property>
+  <property>
+    <name>hbase.hstore.compactionThreshold</name>
+    <value>3</value>
+    <description>
+    If more than this number of HStoreFiles in any one HStore
+    (one HStoreFile is written per flush of memstore) then a compaction
+    is run to rewrite all HStoreFiles files as one.  Larger numbers
+    put off compaction but when it runs, it takes longer to complete.
+    </description>
+  </property>
+  <property>
+    <name>hbase.hstore.blockingStoreFiles</name>
+    <value>7</value>
+    <description>
+    If more than this number of StoreFiles in any one Store
+    (one StoreFile is written per flush of MemStore) then updates are
+    blocked for this HRegion until a compaction is completed, or
+    until hbase.hstore.blockingWaitTime has been exceeded.
+    </description>
+  </property>
+  <property>
+    <name>hbase.hstore.blockingWaitTime</name>
+    <value>90000</value>
+    <description>
+    The time an HRegion will block updates for after hitting the StoreFile
+    limit defined by hbase.hstore.blockingStoreFiles.
+    After this time has elapsed, the HRegion will stop blocking updates even
+    if a compaction has not been completed.  Default: 90 seconds.
+    </description>
+  </property>
+  <property>
+    <name>hbase.hstore.compaction.max</name>
+    <value>10</value>
+    <description>Max number of HStoreFiles to compact per 'minor' compaction.
+    </description>
+  </property>
+  <property>
+    <name>hbase.hregion.majorcompaction</name>
+    <value>86400000</value>
+    <description>The time (in miliseconds) between 'major' compactions of all
+    HStoreFiles in a region.  Default: 1 day.
+    Set to 0 to disable automated major compactions.
+    </description>
+  </property>
+  <property>
+    <name>hbase.mapreduce.hfileoutputformat.blocksize</name>
+    <value>65536</value>
+    <description>The mapreduce HFileOutputFormat writes storefiles/hfiles.
+    This is the minimum hfile blocksize to emit.  Usually in hbase, writing
+    hfiles, the blocksize is gotten from the table schema (HColumnDescriptor)
+    but in the mapreduce outputformat context, we don't have access to the
+    schema so get blocksize from Configuration.  The smaller you make
+    the blocksize, the bigger your index and the less you fetch on a
+    random-access.  Set the blocksize down if you have small cells and want
+    faster random-access of individual cells.
+    </description>
+  </property>
+  <property>
+    <name>hfile.block.cache.size</name>
+    <value>0.25</value>
+    <description>
+        Percentage of maximum heap (-Xmx setting) to allocate to block cache
+        used by HFile/StoreFile. Default of 0.25 means allocate 25%.
+        Set to 0 to disable but it's not recommended.
+    </description>
+  </property>
+  <property>
+    <name>hbase.hash.type</name>
+    <value>murmur</value>
+    <description>The hashing algorithm for use in HashFunction. Two values are
+    supported now: murmur (MurmurHash) and jenkins (JenkinsHash).
+    Used by bloom filters.
+    </description>
+  </property>
+  <property>
+      <name>hfile.block.index.cacheonwrite</name>
+      <value>false</value>
+      <description>
+          This allows to put non-root multi-level index blocks into the block
+          cache at the time the index is being written.
+      </description>
+  </property>
+  <property>
+      <name>hbase.regionserver.checksum.verify</name>
+      <value>false</value>
+      <description>
+         Allow hbase to do checksums rather than using hdfs checksums. This is a backwards
+         incompatible change.
+      </description>
+    </property>
+  <property>
+      <name>hfile.index.block.max.size</name>
+      <value>131072</value>
+      <description>
+          When the size of a leaf-level, intermediate-level, or root-level
+          index block in a multi-level block index grows to this size, the
+          block is written out and a new block is started.
+      </description>
+  </property>
+  <property>
+      <name>hfile.format.version</name>
+      <value>2</value>
+      <description>
+          The HFile format version to use for new files. Set this to 1 to test
+          backwards-compatibility. The default value of this option should be
+          consistent with FixedFileTrailer.MAX_VERSION.
+      </description>
+  </property>
+  <property>
+      <name>io.storefile.bloom.block.size</name>
+      <value>131072</value>
+      <description>
+          The size in bytes of a single block ("chunk") of a compound Bloom
+          filter. This size is approximate, because Bloom blocks can only be
+          inserted at data block boundaries, and the number of keys per data
+          block varies.
+      </description>
+  </property>
+  <property>
+      <name>io.storefile.bloom.cacheonwrite</name>
+      <value>false</value>
+      <description>
+          Enables cache-on-write for inline blocks of a compound Bloom filter.
+      </description>
+  </property>
+  <property>
+      <name>hbase.rs.cacheblocksonwrite</name>
+      <value>false</value>
+      <description>
+          Whether an HFile block should be added to the block cache when the
+          block is finished.
+      </description>
+  </property>
+  <property>
+    <name>hbase.rpc.engine</name>
+    <value>org.apache.hadoop.hbase.ipc.WritableRpcEngine</value>
+    <description>Implementation of org.apache.hadoop.hbase.ipc.RpcEngine to be
+    used for client / server RPC call marshalling.
+    </description>
+  </property>
+
+  <!-- The following properties configure authentication information for
+       HBase processes when using Kerberos security.  There are no default
+       values, included here for documentation purposes -->
+  <property>
+    <name>hbase.master.keytab.file</name>
+    <value></value>
+    <description>Full path to the kerberos keytab file to use for logging in
+    the configured HMaster server principal.
+    </description>
+  </property>
+  <property>
+    <name>hbase.master.kerberos.principal</name>
+    <value></value>
+    <description>Ex. "hbase/_HOST@EXAMPLE.COM".  The kerberos principal name
+    that should be used to run the HMaster process.  The principal name should
+    be in the form: user/hostname@DOMAIN.  If "_HOST" is used as the hostname
+    portion, it will be replaced with the actual hostname of the running
+    instance.
+    </description>
+  </property>
+  <property>
+    <name>hbase.regionserver.keytab.file</name>
+    <value></value>
+    <description>Full path to the kerberos keytab file to use for logging in
+    the configured HRegionServer server principal.
+    </description>
+  </property>
+  <property>
+    <name>hbase.regionserver.kerberos.principal</name>
+    <value></value>
+    <description>Ex. "hbase/_HOST@EXAMPLE.COM".  The kerberos principal name
+    that should be used to run the HRegionServer process.  The principal name
+    should be in the form: user/hostname@DOMAIN.  If "_HOST" is used as the
+    hostname portion, it will be replaced with the actual hostname of the
+    running instance.  An entry for this principal must exist in the file
+    specified in hbase.regionserver.keytab.file
+    </description>
+  </property>
+
+  <!-- Additional configuration specific to HBase security -->
+  <property>
+    <name>hadoop.policy.file</name>
+    <value>hbase-policy.xml</value>
+    <description>The policy configuration file used by RPC servers to make
+      authorization decisions on client requests.  Only used when HBase
+      security is enabled.
+    </description>
+  </property>
+  <property>
+    <name>hbase.superuser</name>
+    <value></value>
+    <description>List of users or groups (comma-separated), who are allowed
+    full privileges, regardless of stored ACLs, across the cluster.
+    Only used when HBase security is enabled.
+    </description>
+  </property>
+  <property>
+    <name>hbase.auth.key.update.interval</name>
+    <value>86400000</value>
+    <description>The update interval for master key for authentication tokens 
+    in servers in milliseconds.  Only used when HBase security is enabled.
+    </description>
+  </property>
+  <property>
+    <name>hbase.auth.token.max.lifetime</name>
+    <value>604800000</value>
+    <description>The maximum lifetime in milliseconds after which an
+    authentication token expires.  Only used when HBase security is enabled.
+    </description>
+  </property>
+
+  <property>
+    <name>zookeeper.session.timeout</name>
+    <value>180000</value>
+    <description>ZooKeeper session timeout.
+      HBase passes this to the zk quorum as suggested maximum time for a
+      session (This setting becomes zookeeper's 'maxSessionTimeout').  See
+      http://hadoop.apache.org/zookeeper/docs/current/zookeeperProgrammers.html#ch_zkSessions
+      "The client sends a requested timeout, the server responds with the
+      timeout that it can give the client. " In milliseconds.
+    </description>
+  </property>
+  <property>
+    <name>zookeeper.znode.parent</name>
+    <value>/hbase</value>
+    <description>Root ZNode for HBase in ZooKeeper. All of HBase's ZooKeeper
+      files that are configured with a relative path will go under this node.
+      By default, all of HBase's ZooKeeper file path are configured with a
+      relative path, so they will all go under this directory unless changed.
+    </description>
+  </property>
+  <property>
+    <name>zookeeper.znode.rootserver</name>
+    <value>root-region-server</value>
+    <description>Path to ZNode holding root region location. This is written by
+      the master and read by clients and region servers. If a relative path is
+      given, the parent folder will be ${zookeeper.znode.parent}. By default,
+      this means the root location is stored at /hbase/root-region-server.
+    </description>
+  </property>
+
+  <property>
+    <name>zookeeper.znode.acl.parent</name>
+    <value>acl</value>
+    <description>Root ZNode for access control lists.</description>
+  </property>
+  
+  <property>
+    <name>hbase.coprocessor.region.classes</name>
+    <value></value>
+    <description>A comma-separated list of Coprocessors that are loaded by
+    default on all tables. For any override coprocessor method, these classes
+    will be called in order. After implementing your own Coprocessor, just put
+    it in HBase's classpath and add the fully qualified class name here.
+    A coprocessor can also be loaded on demand by setting HTableDescriptor.
+    </description>
+  </property>
+
+  <property>
+    <name>hbase.coprocessor.master.classes</name>
+    <value></value>
+    <description>A comma-separated list of
+    org.apache.hadoop.hbase.coprocessor.MasterObserver coprocessors that are
+    loaded by default on the active HMaster process. For any implemented
+    coprocessor methods, the listed classes will be called in order. After
+    implementing your own MasterObserver, just put it in HBase's classpath
+    and add the fully qualified class name here.
+    </description>
+  </property>
+
+  <!--
+  The following three properties are used together to create the list of
+  host:peer_port:leader_port quorum servers for ZooKeeper.
+  -->
+  <property>
+    <name>hbase.zookeeper.quorum</name>
+    <value>localhost</value>
+    <description>Comma separated list of servers in the ZooKeeper Quorum.
+    For example, "host1.mydomain.com,host2.mydomain.com,host3.mydomain.com".
+    By default this is set to localhost for local and pseudo-distributed modes
+    of operation. For a fully-distributed setup, this should be set to a full
+    list of ZooKeeper quorum servers. If HBASE_MANAGES_ZK is set in hbase-env.sh
+    this is the list of servers which we will start/stop ZooKeeper on.
+    </description>
+  </property>
+  <property>
+    <name>hbase.zookeeper.peerport</name>
+    <value>2888</value>
+    <description>Port used by ZooKeeper peers to talk to each other.
+    See http://hadoop.apache.org/zookeeper/docs/r3.1.1/zookeeperStarted.html#sc_RunningReplicatedZooKeeper
+    for more information.
+    </description>
+  </property>
+  <property>
+    <name>hbase.zookeeper.leaderport</name>
+    <value>3888</value>
+    <description>Port used by ZooKeeper for leader election.
+    See http://hadoop.apache.org/zookeeper/docs/r3.1.1/zookeeperStarted.html#sc_RunningReplicatedZooKeeper
+    for more information.
+    </description>
+  </property>
+  <property>
+    <name>hbase.zookeeper.useMulti</name>
+    <value>false</value>
+    <description>Instructs HBase to make use of ZooKeeper's multi-update functionality.
+    This allows certain ZooKeeper operations to complete more quickly and prevents some issues
+    with rare ZooKeeper failure scenarios (see the release note of HBASE-6710 for an example).
+    IMPORTANT: only set this to true if all ZooKeeper servers in the cluster are on version 3.4+
+    and will not be downgraded.  ZooKeeper versions before 3.4 do not support multi-update and will
+    not fail gracefully if multi-update is invoked (see ZOOKEEPER-1495).
+    </description>
+  </property>
+  <!-- End of properties used to generate ZooKeeper host:port quorum list. -->
+
+  <!--
+  Beginning of properties that are directly mapped from ZooKeeper's zoo.cfg.
+  All properties with an "hbase.zookeeper.property." prefix are converted for
+  ZooKeeper's configuration. Hence, if you want to add an option from zoo.cfg,
+  e.g.  "initLimit=10" you would append the following to your configuration:
+    <property>
+      <name>hbase.zookeeper.property.initLimit</name>
+      <value>10</value>
+    </property>
+  -->
+  <property>
+    <name>hbase.zookeeper.property.initLimit</name>
+    <value>10</value>
+    <description>Property from ZooKeeper's config zoo.cfg.
+    The number of ticks that the initial synchronization phase can take.
+    </description>
+  </property>
+  <property>
+    <name>hbase.zookeeper.property.syncLimit</name>
+    <value>5</value>
+    <description>Property from ZooKeeper's config zoo.cfg.
+    The number of ticks that can pass between sending a request and getting an
+    acknowledgment.
+    </description>
+  </property>
+  <property>
+    <name>hbase.zookeeper.property.dataDir</name>
+    <value>${hbase.tmp.dir}/zookeeper</value>
+    <description>Property from ZooKeeper's config zoo.cfg.
+    The directory where the snapshot is stored.
+    </description>
+  </property>
+  <property>
+    <name>hbase.zookeeper.property.clientPort</name>
+    <value>2181</value>
+    <description>Property from ZooKeeper's config zoo.cfg.
+    The port at which the clients will connect.
+    </description>
+  </property>
+  <property>
+    <name>hbase.zookeeper.property.maxClientCnxns</name>
+    <value>300</value>
+    <description>Property from ZooKeeper's config zoo.cfg.
+    Limit on number of concurrent connections (at the socket level) that a
+    single client, identified by IP address, may make to a single member of
+    the ZooKeeper ensemble. Set high to avoid zk connection issues running
+    standalone and pseudo-distributed.
+    </description>
+  </property>
+  <!-- End of properties that are directly mapped from ZooKeeper's zoo.cfg -->
+  <property>
+    <name>hbase.rest.port</name>
+    <value>8080</value>
+    <description>The port for the HBase REST server.</description>
+  </property>
+  <property>
+    <name>hbase.rest.readonly</name>
+    <value>false</value>
+    <description>
+    Defines the mode the REST server will be started in. Possible values are:
+    false: All HTTP methods are permitted - GET/PUT/POST/DELETE.
+    true: Only the GET method is permitted.
+    </description>
+  </property>
+
+  <property skipInDoc="true">
+    <name>hbase.defaults.for.version</name>
+    <value>0.94.7</value>
+    <description>
+    This defaults file was compiled for version 0.94.8. This variable is used
+    to make sure that a user doesn't have an old version of hbase-default.xml on the
+    classpath.
+    </description>
+  </property>
+  <property>
+    <name>hbase.defaults.for.version.skip</name>
+    <value>false</value>
+    <description>
+    Set to true to skip the 'hbase.defaults.for.version' check.
+    Setting this to true can be useful in contexts other than
+    the other side of a maven generation; i.e. running in an
+    ide.  You'll want to set this boolean to true to avoid
+    seeing the RuntimException complaint: "hbase-default.xml file
+    seems to be for and old version of HBase (0.94.8), this
+    version is X.X.X-SNAPSHOT"
+    </description>
+  </property>
+  <property>
+      <name>hbase.coprocessor.abortonerror</name>
+      <value>false</value>
+      <description>
+      Set to true to cause the hosting server (master or regionserver) to
+      abort if a coprocessor throws a Throwable object that is not IOException or
+      a subclass of IOException. Setting it to true might be useful in development
+      environments where one wants to terminate the server as soon as possible to
+      simplify coprocessor failure analysis.
+      </description>
+  </property>
+  <property>
+    <name>hbase.online.schema.update.enable</name>
+    <value>false</value>
+    <description>
+    Set true to enable online schema changes.  This is an experimental feature.  
+    There are known issues modifying table schemas at the same time a region
+    split is happening so your table needs to be quiescent or else you have to
+    be running with splits disabled.
+    </description>
+  </property>
+  <property>
+    <name>dfs.support.append</name>
+    <value>true</value>
+    <description>Does HDFS allow appends to files?
+    This is an hdfs config. set in here so the hdfs client will do append support.
+    You must ensure that this config. is true serverside too when running hbase
+    (You will have to restart your cluster after setting it).
+    </description>
+  </property>
+  <property>
+    <name>hbase.thrift.minWorkerThreads</name>
+    <value>16</value>
+    <description>
+    The "core size" of the thread pool. New threads are created on every
+    connection until this many threads are created.
+    </description>
+  </property>
+  <property>
+    <name>hbase.thrift.maxWorkerThreads</name>
+    <value>1000</value>
+    <description>
+    The maximum size of the thread pool. When the pending request queue
+    overflows, new threads are created until their number reaches this number.
+    After that, the server starts dropping connections.
+    </description>
+  </property>
+  <property>
+     <name>hbase.thrift.maxQueuedRequests</name>
+     <value>1000</value>
+     <description>
+     The maximum number of pending Thrift connections waiting in the queue. If
+     there are no idle threads in the pool, the server queues requests. Only
+     when the queue overflows, new threads are added, up to
+     hbase.thrift.maxQueuedRequests threads.
+     </description>
+   </property>
+     <property>
+     <name>hbase.offheapcache.percentage</name>
+     <value>0</value>
+     <description>
+     The amount of off heap space to be allocated towards the experimental
+     off heap cache. If you desire the cache to be disabled, simply set this
+     value to 0.
+     </description>
+   </property>
+   <property>
+    <name>hbase.data.umask.enable</name>
+    <value>false</value>
+    <description>Enable, if true, that file permissions should be assigned
+      to the files written by the regionserver
+    </description>
+  </property>
+  <property>
+    <name>hbase.data.umask</name>
+    <value>000</value>
+    <description>File permissions that should be used to write data
+      files when hbase.data.umask.enable is true
+    </description>
+  </property>
+
+  <property>
+    <name>hbase.metrics.showTableName</name>
+    <value>true</value>
+    <description>Whether to include the prefix "tbl.tablename" in per-column family metrics.
+	If true, for each metric M, per-cf metrics will be reported for tbl.T.cf.CF.M, if false,
+	per-cf metrics will be aggregated by column-family across tables, and reported for cf.CF.M.
+	In both cases, the aggregated metric M across tables and cfs will be reported.
+    </description>
+  </property>
+  <property>
+    <name>hbase.table.archive.directory</name>
+    <value>.archive</value>
+    <description>Per-table directory name under which to backup files for a
+      table. Files are moved to the same directories as they would be under the
+      table directory, but instead are just one level lower (under
+      table/.archive/... rather than table/...). Currently only applies to HFiles.</description>
+  </property>
+  <property>
+    <name>hbase.master.hfilecleaner.plugins</name>
+    <value>org.apache.hadoop.hbase.master.cleaner.TimeToLiveHFileCleaner</value>
+    <description>A comma-separated list of HFileCleanerDelegate invoked by
+    the HFileCleaner service. These HFiles cleaners are called in order,
+    so put the cleaner that prunes the most files in front. To
+    implement your own HFileCleanerDelegate, just put it in HBase's classpath
+    and add the fully qualified class name here. Always add the above
+    default log cleaners in the list as they will be overwritten in hbase-site.xml.
+    </description>
+  </property>
+  <property>
+    <name>hbase.rest.threads.max</name>
+    <value>100</value>
+    <description>
+        The maximum number of threads of the REST server thread pool.
+        Threads in the pool are reused to process REST requests. This
+        controls the maximum number of requests processed concurrently.
+        It may help to control the memory used by the REST server to
+        avoid OOM issues. If the thread pool is full, incoming requests
+        will be queued up and wait for some free threads. The default
+        is 100.
+    </description>
+  </property>
+  <property>
+    <name>hbase.rest.threads.min</name>
+    <value>2</value>
+    <description>
+        The minimum number of threads of the REST server thread pool.
+        The thread pool always has at least these number of threads so
+        the REST server is ready to serve incoming requests. The default
+        is 2.
+    </description>
+  </property>
+</configuration>

--- a/applications/hbase-sink-with-trigger-on-finish/server/persistence/conf/localhost/hbase-site.xml
+++ b/applications/hbase-sink-with-trigger-on-finish/server/persistence/conf/localhost/hbase-site.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0"?>
+<?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
+<!--
+/**
+ * Copyright 2010 The Apache Software Foundation
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+-->
+<configuration>
+  <property>
+    <name>hbase.rootdir</name>
+    <value>file:///opt/hbase-0.94.8/data</value>
+  </property>
+  <property>
+    <name>hbase.zookeeper.property.dataDir</name>
+    <value>/opt/hbase-0.94.8/data/zookeeper</value>
+  </property>
+</configuration>

--- a/applications/hbase-sink-with-trigger-on-finish/server/persistence/pom.xml
+++ b/applications/hbase-sink-with-trigger-on-finish/server/persistence/pom.xml
@@ -1,0 +1,139 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>org.springframework.integration.samples.server</groupId>
+		<artifactId>server</artifactId>
+		<version>2.2.0.BUILD-SNAPSHOT</version>
+	</parent>
+	<artifactId>persistence</artifactId>
+	<packaging>jar</packaging>
+	<name>HBase client</name>
+
+	<dependencyManagement>
+		<dependencies>
+			<dependency>
+				<groupId>org.apache.httpcomponents</groupId>
+				<version>4.2.3</version>
+				<artifactId>httpclient</artifactId>
+			</dependency>
+			<dependency>
+				<groupId>org.apache.httpcomponents</groupId>
+				<artifactId>httpcore</artifactId>
+				<version>4.2.2</version>
+			</dependency>
+			<dependency>
+				<groupId>org.slf4j</groupId>
+				<artifactId>slf4j-log4j12</artifactId>
+				<version>1.6.1</version>
+			</dependency>
+			<dependency>
+				<groupId>org.slf4j</groupId>
+				<artifactId>slf4j-api</artifactId>
+				<version>1.6.1</version>
+			</dependency>
+		</dependencies>
+	</dependencyManagement>
+	<dependencies>
+		<!-- Test dependencies -->
+		<dependency>
+			<groupId>commons-io</groupId>
+			<artifactId>commons-io</artifactId>
+			<version>2.1</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.integration.samples</groupId>
+			<artifactId>json-utils</artifactId>
+			<version>${project.version}</version>
+			<type>test-jar</type>
+			<scope>test</scope>
+		</dependency>
+
+		<!-- For MD5 hash -->
+		<dependency>
+			<groupId>commons-codec</groupId>
+			<artifactId>commons-codec</artifactId>
+			<version>1.8</version>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.amqp</groupId>
+			<artifactId>spring-rabbit</artifactId>
+			<version>${spring.rabbitmq.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.hadoop</groupId>
+			<artifactId>hadoop-core</artifactId>
+			<version>${hadoop.core.version}</version>
+			<!-- <scope>runtime</scope> -->
+		</dependency>
+		<dependency>
+			<groupId>org.apache.hbase</groupId>
+			<artifactId>hbase</artifactId>
+			<version>${hbase.version}</version>
+			<!-- <scope>runtime</scope> -->
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.integration.samples.client</groupId>
+			<artifactId>queue-client</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+	</dependencies>
+
+	<build>
+		<resources>
+			<resource>
+				<directory>conf/localhost</directory>
+			</resource>
+		</resources>
+		<pluginManagement>
+			<plugins>
+				<plugin>
+					<groupId>com.springsource.bundlor</groupId>
+					<artifactId>com.springsource.bundlor.maven</artifactId>
+					<version>1.0.0.M1B</version>
+				</plugin>
+				<plugin>
+					<artifactId>maven-assembly-plugin</artifactId>
+					<inherited>false</inherited>
+					<configuration>
+						<descriptorRefs>
+							<descriptorRef>project</descriptorRef>
+						</descriptorRefs>
+					</configuration>
+				</plugin>
+			</plugins>
+		</pluginManagement>
+		<plugins>
+			<plugin>
+				<groupId>org.mortbay.jetty</groupId>
+				<artifactId>maven-jetty-plugin</artifactId>
+				<version>6.1.26</version>
+			</plugin>
+
+			<!-- <plugin> -->
+			<!-- <groupId>org.apache.maven.plugins</groupId> -->
+			<!-- <artifactId>maven-shade-plugin</artifactId> -->
+			<!-- <version>2.1</version> -->
+			<!-- <executions> -->
+			<!-- <execution> -->
+			<!-- <phase>package</phase> -->
+			<!-- <goals> -->
+			<!-- <goal>shade</goal> -->
+			<!-- </goals> -->
+			<!-- <configuration> -->
+			<!-- <transformers> -->
+			<!-- <transformer -->
+			<!-- implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer"> -->
+			<!-- <mainClass>org.somepackage.redmap.Driver</mainClass> -->
+			<!-- </transformer> -->
+			<!-- </transformers> -->
+			<!-- </configuration> -->
+			<!-- </execution> -->
+			<!-- </executions> -->
+			<!-- </plugin> -->
+		</plugins>
+	</build>
+
+
+</project>

--- a/applications/hbase-sink-with-trigger-on-finish/server/persistence/src/main/java/org/springframework/integration/samples/beans/HBaseDocument.java
+++ b/applications/hbase-sink-with-trigger-on-finish/server/persistence/src/main/java/org/springframework/integration/samples/beans/HBaseDocument.java
@@ -1,0 +1,34 @@
+package org.springframework.integration.samples.beans;
+
+import java.util.UUID;
+
+import lombok.Getter;
+import lombok.ToString;
+
+import org.springframework.integration.samples.beans.DocumentToIndex;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Domain object representing a document to store in HBase
+ * 
+ * @author Flavio Pompermaier
+ */
+
+@Getter
+@ToString
+public class HBaseDocument {
+
+	@JsonProperty("_id")
+	private final String id;
+	private final DocumentToIndex document;
+
+	public HBaseDocument(DocumentToIndex d) {
+		this.document = d;
+		//TODO find the best row key pattern! (that allows for FuzzyRowFilter)	
+		id = UUID.randomUUID().toString();
+	}
+
+	
+
+}

--- a/applications/hbase-sink-with-trigger-on-finish/server/persistence/src/main/java/org/springframework/integration/samples/hbase/jobs/SampleJob.java
+++ b/applications/hbase-sink-with-trigger-on-finish/server/persistence/src/main/java/org/springframework/integration/samples/hbase/jobs/SampleJob.java
@@ -1,0 +1,75 @@
+package org.springframework.integration.samples.hbase.jobs;
+/*
+ * Compile and run with:
+ * javac -cp `hbase classpath` TestHBase.java 
+ * java -cp `hbase classpath` TestHBase
+ */
+import java.io.IOException;
+import java.util.Date;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hbase.client.Scan;
+import org.apache.hadoop.hbase.mapreduce.TableMapReduceUtil;
+import org.apache.hadoop.hbase.util.Bytes;
+import org.apache.hadoop.io.Text;
+import org.apache.hadoop.mapreduce.Job;
+import org.apache.hadoop.mapreduce.lib.output.NullOutputFormat;
+import org.springframework.integration.samples.hbase.mappers.SampleMapper;
+import org.springframework.integration.samples.hbase.utils.HBaseTableUtils;
+
+/**
+ * MapReduce Job that reads received messages of NER tools and send "transformed" messages to the AMQP queue
+ * 
+ * @author Flavio Pompermaier
+ * */
+public class SampleJob {
+
+	public static final String NAME = "sample";
+	/**
+	 * Sets up the counting job.
+	 * 
+	 * @param conf
+	 *            The current configuration.
+	 * @return The newly created job.
+	 * @throws IOException
+	 *             When setting up the job fails.
+	 * @throws UndefinedAnormConfParameter
+	 *             When the table name is not properly configured.
+	 */
+	public static Job createSampleJob(Configuration conf,
+			String tableToScan, Date start) throws IOException {
+
+		String columnFamily = conf.get("family-column");
+		// final String outputTableName = "test-output";
+		final byte[] family = Bytes.toBytes(columnFamily);
+		final byte[] qualifier = Bytes.toBytes(HBaseTableUtils.JSON_CONTENT_QUALIFIER);
+		
+		// create scanner
+		Scan scan = HBaseTableUtils.getTempStorageScanner(family, qualifier, start);
+
+		Job job = new Job(conf, "Sample Mapreduce job");
+		// Set the Job Jar by finding where a given class came from
+		job.setJarByClass(SampleJob.class);
+		// job.setCombinerClass(EntityCounterCombiner.class);
+		TableMapReduceUtil.initTableMapperJob(tableToScan,// table
+				scan,// scan instance
+				SampleMapper.class,// mapper class
+				Text.class, // mapper output key
+				Text.class, // mapper output value
+				job);// the current job to adjust
+
+		// job.setCombinerClass(SampleCombiner.class);//combiner class
+		// job.setReducerClass(SampleReducer.class); // reducer class
+		job.setOutputKeyClass(Text.class);
+		job.setOutputValueClass(Text.class);
+		// job.setOutputFormatClass(TableOutputFormat.class);
+		// job.getConfiguration().set(TableOutputFormat.OUTPUT_TABLE,
+		// outputTableName);
+		job.setOutputFormatClass(NullOutputFormat.class);
+		job.setNumReduceTasks(0);
+
+		return job;
+	}
+
+	
+}

--- a/applications/hbase-sink-with-trigger-on-finish/server/persistence/src/main/java/org/springframework/integration/samples/hbase/mappers/SampleMapper.java
+++ b/applications/hbase-sink-with-trigger-on-finish/server/persistence/src/main/java/org/springframework/integration/samples/hbase/mappers/SampleMapper.java
@@ -1,0 +1,105 @@
+package org.springframework.integration.samples.hbase.mappers;
+
+import java.io.IOException;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hbase.KeyValue;
+import org.apache.hadoop.hbase.client.Result;
+import org.apache.hadoop.hbase.io.ImmutableBytesWritable;
+import org.apache.hadoop.hbase.mapreduce.TableMapper;
+import org.apache.hadoop.hbase.util.Bytes;
+import org.apache.hadoop.io.Text;
+import org.apache.hadoop.mapreduce.Counter;
+import org.springframework.amqp.rabbit.connection.CachingConnectionFactory;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.amqp.support.converter.Jackson2JsonMessageConverter;
+import org.springframework.integration.samples.beans.DocumentToIndex;
+import org.springframework.integration.samples.beans.RoutingKey;
+import org.springframework.integration.samples.hbase.utils.HBaseTableUtils;
+import org.springframework.integration.samples.producer.gateway.HBaseGateway;
+
+import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+public class SampleMapper extends TableMapper<Text, Text> {
+
+	private static final String GROUP_NAME = "SAMPLE";
+	private static final String PROGRESS_COUNTER_NAME = "inspected_rows";
+	private final HBaseGateway gw = new HBaseGateway();
+	
+	/**
+	 * Maps the data from (row, values) to (null, null)
+	 * 
+	 * @param row
+	 *            The current table row key.
+	 * @param columns
+	 *            The columns.
+	 * @param context
+	 *            The current context.
+	 * @throws IOException
+	 *             When something is broken with the data.
+	 * @throws InterruptedException
+	 * @see org.apache.hadoop.mapreduce.Mapper#map(KEYIN, VALUEIN,
+	 *      org.apache.hadoop.mapreduce.Mapper.Context)
+	 */
+	@Override
+	public void map(ImmutableBytesWritable row, Result columns, Context context)
+			throws IOException, InterruptedException {
+		for (KeyValue column : columns.list()) {
+			final byte[] columnValue = column.getValue();
+			final byte[] columnFamily = column.getFamily();
+			final byte[] columnQualifier = column.getQualifier();
+			final String family = Bytes.toString(columnFamily);
+			final String qual = Bytes.toString(columnQualifier);
+			Configuration conf = context.getConfiguration();
+			String valueFamily = conf.get("family-column");//value
+			// byte [] columnBytes = KeyValue.makeColumn(columnFamily,
+			// columnQualifier);
+			boolean isJsonColumn = valueFamily.equals(family)
+					&& HBaseTableUtils.JSON_CONTENT_QUALIFIER.equals(qual);
+			if (columnValue.length > 0 && isJsonColumn) {
+				//track progress
+				final Counter progressCounter = getProgressCounter(context);
+				progressCounter.increment(1);
+				DocumentToIndex docToIndex = deserializeDoc(columnValue);
+				docToIndex.setRoutingKey(RoutingKey.secondstep);
+				docToIndex.setSource(docToIndex.getSource());
+				gw.sendDocumentToPersist(docToIndex);
+			}
+		}
+	}
+	
+	private Counter getProgressCounter(final Context context) {
+		return context.getCounter(GROUP_NAME, PROGRESS_COUNTER_NAME);
+	}
+	private DocumentToIndex deserializeDoc(byte[] columnValue)
+			throws IOException, JsonParseException, JsonMappingException {
+		String jsonString = Bytes.toString(columnValue);
+		final ObjectMapper mapper = new ObjectMapper();
+		return mapper.readValue(jsonString, DocumentToIndex.class);
+	}
+
+	@Override
+	protected void setup(Context context)
+			throws IOException, InterruptedException {
+		super.setup(context);
+		Configuration conf = context.getConfiguration();
+		String queueHost = conf.get("queue-host");//localhost
+		final String portStr = conf.get("queue-port");
+		int queuePort = new Integer(portStr);//5672
+		String adminUsername = conf.get("queue-adminuser");//guest
+		String adminPassword = conf.get("queue-adminpwd");//guest
+		String directExchange = conf.get("queue-exchange");
+		
+		CachingConnectionFactory connectionFactory = new CachingConnectionFactory(queueHost);
+		connectionFactory.setUsername(adminUsername);
+		connectionFactory.setPassword(adminPassword);
+		connectionFactory.setPort(queuePort);
+		RabbitTemplate rabbitTemplate = new RabbitTemplate(connectionFactory);
+		rabbitTemplate.setMessageConverter(new Jackson2JsonMessageConverter());
+		rabbitTemplate.setExchange(directExchange);
+		gw.setRabbitTemplate(rabbitTemplate);
+	}
+
+}

--- a/applications/hbase-sink-with-trigger-on-finish/server/persistence/src/main/java/org/springframework/integration/samples/hbase/utils/HBaseTableUtils.java
+++ b/applications/hbase-sink-with-trigger-on-finish/server/persistence/src/main/java/org/springframework/integration/samples/hbase/utils/HBaseTableUtils.java
@@ -1,0 +1,213 @@
+package org.springframework.integration.samples.hbase.utils;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.SynchronousQueue;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hbase.HBaseConfiguration;
+import org.apache.hadoop.hbase.HColumnDescriptor;
+import org.apache.hadoop.hbase.HTableDescriptor;
+import org.apache.hadoop.hbase.TableExistsException;
+import org.apache.hadoop.hbase.TableNotFoundException;
+import org.apache.hadoop.hbase.ZooKeeperConnectionException;
+import org.apache.hadoop.hbase.client.HBaseAdmin;
+import org.apache.hadoop.hbase.client.HConnection;
+import org.apache.hadoop.hbase.client.HConnectionManager;
+import org.apache.hadoop.hbase.client.HTable;
+import org.apache.hadoop.hbase.client.Put;
+import org.apache.hadoop.hbase.client.Row;
+import org.apache.hadoop.hbase.client.Scan;
+import org.apache.hadoop.hbase.regionserver.StoreFile.BloomType;
+import org.apache.hadoop.hbase.util.Bytes;
+import org.apache.hadoop.hbase.util.Threads;
+import org.springframework.integration.samples.beans.DocumentToIndex;
+import org.springframework.integration.samples.beans.HBaseDocument;
+import org.springframework.integration.samples.beans.ProcessedDocument;
+
+import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+public class HBaseTableUtils {
+
+	public static final String JSON_CONTENT_QUALIFIER = "json";
+	private static final int MAX = 16;
+	private static final String THREAD_POOL_PREFIX = "hbase-table-pool";
+
+	public static Date getDayBefore(Date date) {
+
+		Calendar cal = Calendar.getInstance();
+		cal.setTime(date);
+		cal.add(Calendar.DAY_OF_MONTH, -1);
+		return cal.getTime();
+	}
+	
+	public static void deleteTable(String tableName) throws IOException {
+		Configuration conf = HBaseConfiguration.create();
+		HBaseAdmin hbaseAdmin = new HBaseAdmin(conf);
+		try{
+			hbaseAdmin.disableTable(tableName);
+			hbaseAdmin.deleteTable(tableName);
+			hbaseAdmin.close();
+		}catch(TableNotFoundException ex){
+			//ignore
+		}
+	}
+	/**
+	 * Create a table if it doesn't exists
+	 * 
+	 * @param tableName
+	 * @param conf
+	 * @param hbaseAdmin
+	 * @param families
+	 * @return An HTable instance for the created table.
+	 * @throws IOException
+	 */
+	public static void createTableIfNotExists(String tableName,
+			String familyStr, Configuration conf) throws IOException {
+		final byte[] tableNameArray = Bytes.toBytes(tableName);
+		final byte[] family = Bytes.toBytes(familyStr);
+
+		try {
+			createTable(tableNameArray, family, conf);
+		} catch (TableExistsException e) {
+			// do not throw error in this case
+		}
+	}
+
+	private static HTable createTable(byte[] tableName, byte[] family,
+			Configuration conf) throws IOException {
+		HTableDescriptor desc = new HTableDescriptor(tableName);
+		HColumnDescriptor hcd = new HColumnDescriptor(family);
+		//TODO requires installation of snappy lib in Hbase installation
+		//hcd.setCompressionType(Algorithm.SNAPPY);
+		
+		// Disable blooms (they are on by default as of 0.95) but we disable
+		// them here because
+		// tests have hard coded counts of what to expect in block cache,
+		// etc., and blooms being on is interfering.
+		hcd.setBloomFilterType(BloomType.NONE);
+		desc.addFamily(hcd);
+		Configuration c = new Configuration(conf);
+		HBaseAdmin hbaseAdmin = new HBaseAdmin(conf);
+		hbaseAdmin.createTable(desc);
+		hbaseAdmin.close();
+		return new HTable(c, tableName);
+	}
+
+	public static void persist(List<ProcessedDocument> docs, String tableName, String familyColumn) {
+		try {
+			Configuration conf = HBaseConfiguration.create();
+			HConnection conn = HConnectionManager.createConnection(conf);
+			createTableIfNotExists(tableName, familyColumn, conf);
+
+			List<Row> rows = generateBatchBulk(docs,familyColumn);
+			writeBulk(tableName, conn, rows);
+		} catch (ZooKeeperConnectionException e) {
+			e.printStackTrace();
+		} catch (IOException e) {
+			e.printStackTrace();
+		}
+
+	}
+
+	private static void writeBulk(String tableName, HConnection conn,
+			List<Row> rows) throws IOException {
+
+		ExecutorService pool = getPool();
+		HTable table = null;
+		try {
+			table = new HTable(Bytes.toBytes(tableName), conn, pool);
+			table.batch(rows);
+		} catch (InterruptedException ix) {
+			throw new IOException(ix);
+		} finally {
+			if (table != null) {
+				table.close();
+			}
+		}
+	}
+
+	private static ExecutorService getPool() {
+		ExecutorService pool = new ThreadPoolExecutor(1, MAX, 60,
+				TimeUnit.SECONDS, new SynchronousQueue<Runnable>(),
+				Threads.newDaemonThreadFactory(THREAD_POOL_PREFIX));
+		((ThreadPoolExecutor) pool).allowCoreThreadTimeOut(true);
+		return pool;
+	}
+
+	private static List<Row> generateBatchBulk(List<ProcessedDocument> docs, String familyColumn) {
+		List<Row> rows = new ArrayList<Row>();
+		for (ProcessedDocument pd : docs) {
+			Put put = getProcessedDocAsPut(pd,familyColumn);
+			rows.add(put);
+		}
+		return rows;
+	}
+	private static Put getProcessedDocAsPut(ProcessedDocument pd, String familyColumn) {
+		// set row key
+		Put put = new Put(Bytes.toBytes(pd.getId()));
+
+		// set value of value:json column
+		String docJSON;
+		try {
+			docJSON = new ObjectMapper().writeValueAsString(pd);
+			final byte[] cfBytes = Bytes.toBytes(familyColumn);
+			final byte[] qualifierBytes = Bytes.toBytes(JSON_CONTENT_QUALIFIER);
+			final byte[] jsonBytes = Bytes.toBytes(docJSON);
+			put.add(cfBytes, qualifierBytes, jsonBytes);
+		} catch (JsonProcessingException e) {
+			e.printStackTrace();
+		}
+		return put;
+	}
+
+	public static Put getDocToIndexAsPut(DocumentToIndex doc2index, String familyColumn) {
+		HBaseDocument m = new HBaseDocument(doc2index);
+		final String id = m.getId();
+		Put put = new Put(Bytes.toBytes(id));
+		ObjectMapper mapper = new ObjectMapper();
+		String docJSON;
+		try {
+			docJSON = mapper.writeValueAsString(m.getDocument());
+			final byte[] cfBytes = Bytes.toBytes(familyColumn);
+			final byte[] qualifierBytes = Bytes.toBytes(JSON_CONTENT_QUALIFIER);
+			final byte[] jsonBytes = Bytes.toBytes(docJSON);
+			put.add(cfBytes, qualifierBytes, jsonBytes);
+			return put;
+		} catch (JsonProcessingException e) {
+			e.printStackTrace();
+		}
+		return null;
+	}
+	public static ProcessedDocument deserializeDoc(String jsonString)
+			throws IOException, JsonParseException, JsonMappingException {
+		final ObjectMapper mapper = new ObjectMapper();
+		return mapper.readValue(jsonString, ProcessedDocument.class);
+	}
+	
+	public static Scan getTempStorageScanner(byte[] family, byte[] qualifier,
+			Date start) throws IOException {
+		Scan scan = new Scan();
+		scan.setCacheBlocks(false); // don't set to true for MR jobs
+		// filter by timestamps
+		if(start!=null){
+			//TODO better management of synch!
+			Date yesterday = HBaseTableUtils.getDayBefore(start);
+			scan.setTimeRange(yesterday.getTime(), Long.MAX_VALUE);
+		}
+		scan.addColumn(family, qualifier);
+		scan.setCaching(1000);// 1000
+		scan.setMaxVersions(1);// only last version
+		return scan;
+	}
+
+}

--- a/applications/hbase-sink-with-trigger-on-finish/server/persistence/src/main/resources/log4j.properties
+++ b/applications/hbase-sink-with-trigger-on-finish/server/persistence/src/main/resources/log4j.properties
@@ -1,0 +1,18 @@
+log4j.rootCategory=INFO, stdout, file
+
+log4j.appender.stdout=org.apache.log4j.ConsoleAppender
+log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
+
+#log4j.appender.stdout.layout.ConversionPattern=%d %p [%c] - <%m>%n
+log4j.appender.stdout.layout.ConversionPattern=%-5p [%40.40c{4}]: %m%n
+
+log4j.category.org.springframework.amqp.rabbit=INFO
+log4j.category.org.springframework.beans.factory=INFO
+ 
+# Direct log messages to a log file
+log4j.appender.file=org.apache.log4j.RollingFileAppender
+log4j.appender.file.File=/tmp/ens-buffer.log
+log4j.appender.file.MaxFileSize=500MB
+log4j.appender.file.MaxBackupIndex=2
+log4j.appender.file.layout=org.apache.log4j.PatternLayout
+log4j.appender.file.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss} %-5p %c{1}:%L - %m%n

--- a/applications/hbase-sink-with-trigger-on-finish/server/persistence/src/test/java/org/springframework/integration/samples/hbase/test/TestHBase.java
+++ b/applications/hbase-sink-with-trigger-on-finish/server/persistence/src/test/java/org/springframework/integration/samples/hbase/test/TestHBase.java
@@ -1,0 +1,85 @@
+package org.springframework.integration.samples.hbase.test;
+/*
+ * Compile and run with:
+ * javac -cp `hbase classpath` TestHBase.java 
+ * java -cp `hbase classpath` TestHBase
+ */
+import java.io.IOException;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hbase.HBaseConfiguration;
+import org.apache.hadoop.hbase.client.HBaseAdmin;
+import org.apache.hadoop.hbase.client.HTable;
+import org.apache.hadoop.hbase.client.Result;
+import org.apache.hadoop.hbase.client.ResultScanner;
+import org.apache.hadoop.hbase.client.Scan;
+import org.apache.hadoop.hbase.util.Bytes;
+import org.springframework.integration.samples.beans.DocumentToIndex;
+import org.springframework.integration.samples.beans.HBaseDocument;
+import org.springframework.integration.samples.json.test.JsonMocksGenerator;
+
+import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+public class TestHBase {
+	private static final String TEST_TABLE = "test";
+	public static void main(String[] args) throws Exception {
+		createTestDoc();
+		if(true)
+			System.exit(0);
+		Configuration conf = HBaseConfiguration.create();
+		HBaseAdmin admin = new HBaseAdmin(conf);
+		// 1 - test connection (essentially)
+//		HTableDescriptor[] tables = admin.listTables();
+//		for (HTableDescriptor hTableDescriptor : tables) {
+//			System.out.println(hTableDescriptor);
+//		}
+
+		// 2 - test creation of a record
+		try {
+			HTable table = new HTable(conf, TEST_TABLE);
+//			HBaseDocument testDoc = createTestDoc();
+//			storeDocument(testDoc, table);
+//			if(true)
+//				System.exit(0);
+
+			// 3 - test row filter
+			scanByTimestampAndKey(table);
+		} finally {
+			admin.close();
+		}
+	}
+	private static void scanByTimestampAndKey(HTable table) throws IOException {
+		Scan scan = new Scan();
+		//filter by timestamps
+		//scan.setTimeRange(1372844707703L, Long.MAX_VALUE);
+		scan.setTimeRange(1372844707704L, Long.MAX_VALUE);//
+		final byte[] cfBytes = Bytes.toBytes("value");
+		final byte[] qualifierBytes = Bytes.toBytes("json");
+		scan.addColumn(cfBytes, qualifierBytes);
+//		Filter filter1 = new RowFilter(
+//				CompareFilter.CompareOp.GREATER_OR_EQUAL,
+//				new SubstringComparator("000|000|000|"));
+//		scan.setFilter(filter1);
+		ResultScanner scanner1 = table.getScanner(scan);
+		final ObjectMapper mapper = new ObjectMapper();
+		for (Result res : scanner1) {
+			deserializeAndPrint(cfBytes, qualifierBytes, mapper, res);
+		}
+		scanner1.close();
+	}
+	private static void deserializeAndPrint(final byte[] cfBytes,
+			final byte[] qualifierBytes, final ObjectMapper mapper, Result res)
+			throws IOException, JsonParseException, JsonMappingException {
+		byte[] value = res.getValue(cfBytes,qualifierBytes);
+		String jsonString = Bytes.toString(value);
+		DocumentToIndex d = mapper.readValue(jsonString, DocumentToIndex.class);
+		System.out.println(d);
+	}
+	private static HBaseDocument createTestDoc() {
+		DocumentToIndex d = JsonMocksGenerator.generateFakeDocument();
+		HBaseDocument m = new HBaseDocument(d);
+		return m;
+	}
+}

--- a/applications/hbase-sink-with-trigger-on-finish/server/persistence/src/test/java/org/springframework/integration/samples/hbase/test/TestMapRedJobs.java
+++ b/applications/hbase-sink-with-trigger-on-finish/server/persistence/src/test/java/org/springframework/integration/samples/hbase/test/TestMapRedJobs.java
@@ -1,0 +1,32 @@
+package org.springframework.integration.samples.hbase.test;
+
+import java.util.Calendar;
+import java.util.Date;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hbase.HBaseConfiguration;
+import org.apache.hadoop.mapreduce.Job;
+import org.junit.Test;
+import org.springframework.integration.samples.hbase.jobs.SampleJob;
+
+
+public class TestMapRedJobs {
+
+	@Test
+	public void testMapReduceJob() throws Exception {
+		Configuration conf = HBaseConfiguration.create();
+		Date yesterady = getDayBefore(new Date());
+		Job job = SampleJob.createSampleJob(conf, "mysource", yesterady);
+		boolean success = job.waitForCompletion(true);
+		String successStr = success ? "successfully" : "with errors";
+		System.out.println("Sample mapreduce job completed " + successStr);
+	}
+
+	private static Date getDayBefore(Date date) {
+
+		Calendar cal = Calendar.getInstance();
+		cal.setTime(date);
+		cal.add(Calendar.DAY_OF_MONTH, -1);
+		return cal.getTime();
+	}
+}

--- a/applications/hbase-sink-with-trigger-on-finish/server/persistence/src/test/java/org/springframework/integration/samples/hbase/test/TestUtils.java
+++ b/applications/hbase-sink-with-trigger-on-finish/server/persistence/src/test/java/org/springframework/integration/samples/hbase/test/TestUtils.java
@@ -1,0 +1,48 @@
+package org.springframework.integration.samples.hbase.test;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+
+import org.junit.Test;
+import org.springframework.integration.samples.beans.DocumentMeta;
+import org.springframework.integration.samples.beans.ProcessedDocument;
+import org.springframework.integration.samples.beans.RoutingKey;
+import org.springframework.integration.samples.hbase.utils.HBaseTableUtils;
+
+public class TestUtils {
+	
+	@Test
+	public void testCreateTable() throws IOException{
+		List<ProcessedDocument> docs = new ArrayList<ProcessedDocument>();
+		HBaseTableUtils.persist(docs, "test-output", "value");
+	}
+	
+	@Test
+	public void testTableDeletion() throws IOException{
+		HBaseTableUtils.deleteTable("test-output");
+	}
+
+	
+	@Test
+	public void testPersist() throws IOException{
+		List<ProcessedDocument> docs = new ArrayList<ProcessedDocument>();
+		generateFakeProcessedDoc(docs);
+		HBaseTableUtils.persist(docs, "test-output","value");
+	}
+
+	private void generateFakeProcessedDoc(List<ProcessedDocument> docs) {
+		ProcessedDocument od = new ProcessedDocument();
+		od.setSource(RoutingKey.mysource.toString());
+		DocumentMeta meta = new DocumentMeta();
+		meta.setTimestamp(new Date().getTime());
+		meta.setLanguage("en");
+		List<String> categories= new ArrayList<String>();
+		categories.add("software");
+		meta.setCategories(categories);
+		od.setMeta(meta);
+		od.setUrl("http://test.it/someurl");
+		docs.add(od);
+	}
+}

--- a/applications/hbase-sink-with-trigger-on-finish/server/pom.xml
+++ b/applications/hbase-sink-with-trigger-on-finish/server/pom.xml
@@ -1,0 +1,20 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>org.springframework.integration.samples</groupId>
+		<artifactId>hbase-sink-with-trigger-on-finish</artifactId>
+		<version>2.2.0.BUILD-SNAPSHOT</version>
+	</parent>
+	<groupId>org.springframework.integration.samples.server</groupId>
+	<artifactId>server</artifactId>
+	<packaging>pom</packaging>
+	<name>ENS AMQP queue server side</name>
+	
+	<modules>
+		<module>curator</module>
+		<module>persistence</module>
+		<module>consumer</module>
+	</modules>
+
+</project>

--- a/applications/pom.xml
+++ b/applications/pom.xml
@@ -13,6 +13,7 @@
 		<module>cafe</module>
 		<module>loan-broker</module>
 		<module>loanshark</module>
+		<module>hbase-sink-with-trigger-on-finish</module>
 	</modules>
 
 </project>


### PR DESCRIPTION
HI, I'd like to integrate this example in the official repository (like described in ticket INTSAMPLES-115).

It implements the competing consumers pattern where you can add more consumers to a queue, plus a synchronization mechanism on stop to trigger some action.
In this scenario sources sends JSON messages to a queue and consumers put them into an HBase table, until a message with a "stop" flag tell the consumers to stop. The consumer receiving the "stop" message sends an official stop message to a topic exchange in order to deliver the stop to all consumers of that queue plus a controller that waits for all the consumers of that queue to stop (it knows how many are there thanks to zookeeper/curator), or after a timeout.
Then the controller of the queue perform some action and once finished send a restart message to consumers of the queue. In my original example it calls an external REST service and then it saves data to Solr but I removed that part because it reuse the same principle in the end.
I know it should be more well documented but I'd like to know if it worth of it or not. Moreover I don't have much time but I think this example could be very interesting for the community!

Thanks,
Flavio