### PR TITLE
INTSAMPLES-138: Make SI 4.1 as minimal

### DIFF
--- a/applications/loan-broker/src/main/java/org/springframework/integration/samples/loanbroker/LoanQuoteAggregator.java
+++ b/applications/loan-broker/src/main/java/org/springframework/integration/samples/loanbroker/LoanQuoteAggregator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2010 the original author or authors.
+ * Copyright 2002-2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,8 +19,8 @@ package org.springframework.integration.samples.loanbroker;
 import java.util.Collections;
 import java.util.List;
 
-import org.springframework.integration.annotation.Header;
 import org.springframework.integration.samples.loanbroker.domain.LoanQuote;
+import org.springframework.messaging.handler.annotation.Header;
 
 /**
  * Aggregates {@link LoanQuote}s based on the value of the 'RESPONSE_TYPE' message header.
@@ -28,19 +28,20 @@ import org.springframework.integration.samples.loanbroker.domain.LoanQuote;
  * of 'BEST'. In this example, that value is set by the 'gateway' when the
  * {@link LoanBrokerGateway#getBestLoanQuote(org.springframework.integration.samples.loanbroker.domain.LoanRequest)}
  * method is invoked by the client.
- * 
+ *
  * @author Oleg Zhurakousky
  */
 public class LoanQuoteAggregator {
 
 	/**
 	 * Aggregates LoanQuote Messages to return a single reply Message.
-	 * 
+	 *
 	 * @param quotes list of loan quotes received from upstream lenders
 	 * @param responseType header that indicates the response type
 	 * @return the best {@link LoanQuote} if the 'RESPONSE_TYPE' header value is 'BEST' else all quotes
 	 */
-	public Object aggregateQuotes(List<LoanQuote> quotes, @Header(value="RESPONSE_TYPE", required=false) String responseType) {
+	public Object aggregateQuotes(List<LoanQuote> quotes,
+			@Header(value="RESPONSE_TYPE", required=false) String responseType) {
 		Collections.sort(quotes);
 		return ("BEST".equals(responseType)) ? quotes.get(0) : quotes;
 	}

--- a/basic/feed/src/test/java/org/springframework/integration/samples/feed/FeedInboundChannelAdapterSample.java
+++ b/basic/feed/src/test/java/org/springframework/integration/samples/feed/FeedInboundChannelAdapterSample.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.springframework.integration.samples.feed;
 
 import org.junit.Test;
@@ -22,7 +23,7 @@ import org.springframework.context.support.ClassPathXmlApplicationContext;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.PollableChannel;
 
-import com.sun.syndication.feed.synd.SyndEntry;
+import com.rometools.rome.feed.synd.SyndEntry;
 
 /**
  * @author Oleg Zhurakousky
@@ -48,4 +49,5 @@ public class FeedInboundChannelAdapterSample {
 		}
 		ac.close();
 	}
+
 }

--- a/basic/jdbc/src/main/java/org/springframework/integration/samples/jdbc/service/PersonService.java
+++ b/basic/jdbc/src/main/java/org/springframework/integration/samples/jdbc/service/PersonService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2011 the original author or authors.
+ * Copyright 2002-2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.springframework.integration.samples.jdbc.service;
 
 import java.util.List;
@@ -28,16 +29,16 @@ public interface PersonService {
 
 	/**
 	 * Creates a {@link Person} instance from the {@link Person} instance passed
-	 * 
-	 * @param the created person instance, it will contain the generated primary key and the formated name
-	 * @return
+	 *
+	 * @param person created person instance, it will contain the generated primary key and the formatted name
+	 * @return the retrieved {@link Person}
 	 */
 	Person createPerson(Person person);
-	
+
 	/**
-	 * Find the person by the person name, the name search is case insensitive, however the 
+	 * Find the person by the person name, the name search is case insensitive, however the
 	 * spaces are not ignored
-	 *  
+	 *
 	 * @param name
 	 * @return the matching {@link Person} record
 	 */

--- a/basic/jpa/src/main/java/org/springframework/integration/samples/jpa/service/PersonService.java
+++ b/basic/jpa/src/main/java/org/springframework/integration/samples/jpa/service/PersonService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2012 the original author or authors.
+ * Copyright 2002-2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,12 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.springframework.integration.samples.jpa.service;
 
 import java.util.List;
 
-import org.springframework.integration.annotation.Payload;
 import org.springframework.integration.samples.jpa.Person;
+import org.springframework.messaging.handler.annotation.Payload;
 
 /**
  * The Service is used to create Person instance in database
@@ -32,7 +33,7 @@ public interface PersonService {
 	/**
 	 * Creates a {@link Person} instance from the {@link Person} instance passed
 	 *
-	 * @param the created person instance, it will contain the generated primary key and the formated name
+	 * @param person created person instance, it will contain the generated primary key and the formated name
 	 * @return The persisted Entity
 	 */
 	Person createPerson(Person person);

--- a/basic/mongodb/src/main/java/org/springframework/integration/samples/mongodb/util/StringConverter.java
+++ b/basic/mongodb/src/main/java/org/springframework/integration/samples/mongodb/util/StringConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2012 the original author or authors.
+ * Copyright 2002-2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,10 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.springframework.integration.samples.mongodb.util;
 
 import org.springframework.data.mapping.context.MappingContext;
 import org.springframework.data.mongodb.MongoDbFactory;
+import org.springframework.data.mongodb.core.convert.DefaultDbRefResolver;
 import org.springframework.data.mongodb.core.convert.MappingMongoConverter;
 import org.springframework.data.mongodb.core.mapping.MongoPersistentEntity;
 import org.springframework.data.mongodb.core.mapping.MongoPersistentProperty;
@@ -24,6 +26,7 @@ import org.springframework.util.StringUtils;
 
 import com.mongodb.BasicDBObject;
 import com.mongodb.DBObject;
+
 /**
  *
  * @author Oleg Zhurakousky
@@ -33,8 +36,9 @@ public class StringConverter extends MappingMongoConverter {
 	public StringConverter(
 			MongoDbFactory mongoDbFactory,
 			MappingContext<? extends MongoPersistentEntity<?>, MongoPersistentProperty> mappingContext) {
-		super(mongoDbFactory, mappingContext);
+		super(new DefaultDbRefResolver(mongoDbFactory), mappingContext);
 	}
+
 	@Override
 	public void write(Object source, DBObject target) {
 		String strPerson = (String) source;
@@ -52,14 +56,13 @@ public class StringConverter extends MappingMongoConverter {
 	@SuppressWarnings("unchecked")
 	@Override
 	public <S> S read(Class<S> clazz, DBObject source) {
-		StringBuffer buffer = new StringBuffer();
-		buffer.append(source.get("fname") + ", ");
-		buffer.append(source.get("lname") + ", ");
-		buffer.append(source.get("city") + ", ");
-		buffer.append(source.get("street") + ", ");
-		buffer.append(source.get("zip") + ", ");
-		buffer.append(source.get("state") + ", ");
-		return (S) buffer.toString();
+		return (S) ((source.get("fname") + ", ")
+				+ source.get("lname") + ", "
+				+ source.get("city") + ", "
+				+ source.get("street") + ", "
+				+ source.get("zip") + ", "
+				+ source.get("state") + ", ");
 	}
+
 }
 

--- a/basic/testing-examples/src/main/java/org/springframework/integration/samples/testing/gateway/VoidGateway.java
+++ b/basic/testing-examples/src/main/java/org/springframework/integration/samples/testing/gateway/VoidGateway.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2012 the original author or authors.
+ * Copyright 2002-2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,10 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.springframework.integration.samples.testing.gateway;
 
-import org.springframework.integration.annotation.Header;
 import org.springframework.integration.file.FileHeaders;
+import org.springframework.messaging.handler.annotation.Header;
 
 /**
  * @author Gary Russell

--- a/build.gradle
+++ b/build.gradle
@@ -14,6 +14,7 @@ ext {
 
 buildscript {
 	repositories {
+		maven { url 'http://repo.spring.io/libs-snapshot' }
 		maven { url "http://repo.spring.io/libs-milestone" }
 	}
 	dependencies {
@@ -191,10 +192,9 @@ subprojects { subproject ->
 			postgresVersion = '9.1-901-1.jdbc4'
 			subethasmtpVersion = '1.2'
 			slf4jVersion = '1.7.6'
-			springIntegrationVersion = '4.0.4.RELEASE'
-			springIntegration41Version = '4.1.0.BUILD-SNAPSHOT'
+			springIntegrationVersion = '4.1.0.RC1'
 			springIntegrationDslVersion = '1.0.0.M3'
-			springVersion = '4.0.7.RELEASE'
+			springVersion = '4.1.1.RELEASE'
 			springSecurityVersion = '3.2.4.RELEASE'
 			springWebFlowVersion = '2.3.3.RELEASE'
 			tilesJspVersion = '2.2.1'
@@ -520,8 +520,8 @@ project('si4demo') {
 	dependencies {
 		compile 'org.springframework.boot:spring-boot-starter-web'
 		compile 'org.springframework.boot:spring-boot-starter-integration'
-		compile "org.springframework.integration:spring-integration-mail:$springIntegration41Version"
-		compile "org.springframework.integration:spring-integration-twitter:$springIntegration41Version"
+		compile "org.springframework.integration:spring-integration-mail"
+		compile "org.springframework.integration:spring-integration-twitter"
 		compile "org.springframework.integration:spring-integration-java-dsl:$springIntegrationDslVersion"
 		compile "javax.mail:javax.mail-api:$javaxMailVersion"
 		compile "com.sun.mail:javax.mail:$javaxMailVersion"
@@ -550,7 +550,7 @@ project('cafe-dsl') {
 	dependencies {
 		compile project(":cafe-si")
 		compile 'org.springframework.boot:spring-boot-starter-integration'
-		compile "org.springframework.integration:spring-integration-core:$springIntegration41Version"
+		compile "org.springframework.integration:spring-integration-core"
 		compile "org.springframework.integration:spring-integration-java-dsl:$springIntegrationDslVersion"
 
 		testCompile 'org.springframework.boot:spring-boot-starter-test'
@@ -825,7 +825,7 @@ project('async-gateway') {
 	sourceCompatibility = 1.8
 
 	dependencies {
-		compile "org.springframework.integration:spring-integration-core:$springIntegration41Version"
+		compile "org.springframework.integration:spring-integration-core:$springIntegrationVersion"
 		compile "org.projectreactor.spring:reactor-spring-context:$reactorSpringVersion"
 	}
 }
@@ -1104,7 +1104,7 @@ project('web-sockets') {
 
 	dependencies {
 		compile 'org.springframework.boot:spring-boot-starter-websocket'
-		compile "org.springframework.integration:spring-integration-websocket:$springIntegration41Version"
+		compile "org.springframework.integration:spring-integration-websocket"
 
 		testCompile 'org.springframework.boot:spring-boot-starter-test'
 	}
@@ -1123,9 +1123,9 @@ project('stomp-chat') {
 
 	dependencies {
 		compile 'org.springframework.boot:spring-boot-starter-websocket'
-		compile "org.springframework.integration:spring-integration-websocket:$springIntegration41Version"
-		compile "org.springframework.integration:spring-integration-event:$springIntegration41Version"
-		compile "org.springframework.integration:spring-integration-groovy:$springIntegration41Version"
+		compile "org.springframework.integration:spring-integration-websocket"
+		compile "org.springframework.integration:spring-integration-event"
+		compile "org.springframework.integration:spring-integration-groovy"
 
 		testCompile 'org.springframework.boot:spring-boot-starter-test'
 	}

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
 version=3.0.0.BUILD-SNAPSHOT
-springBootVersion=1.1.7.RELEASE
+springBootVersion=1.2.0.BUILD-SNAPSHOT

--- a/intermediate/retry-and-more/src/main/java/org/springframework/integration/samples/advice/ConditionalService.java
+++ b/intermediate/retry-and-more/src/main/java/org/springframework/integration/samples/advice/ConditionalService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2012 the original author or authors.
+ * Copyright 2002-2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.springframework.integration.samples.advice;
 
 import java.util.Calendar;
@@ -22,7 +23,8 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.springframework.integration.annotation.Header;
+
+import org.springframework.messaging.handler.annotation.Header;
 
 /**
  * @author Gary Russell
@@ -72,4 +74,5 @@ public class ConditionalService {
 		}
 		logger.info("Service success for " + payload);
 	}
+
 }

--- a/intermediate/stored-procedures-derby/src/main/java/org/springframework/integration/samples/storedprocedure/service/CoffeeService.java
+++ b/intermediate/stored-procedures-derby/src/main/java/org/springframework/integration/samples/storedprocedure/service/CoffeeService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2011 the original author or authors
+ * Copyright 2002-2014 the original author or authors
  *
  *     Licensed under the Apache License, Version 2.0 (the "License");
  *     you may not use this file except in compliance with the License.
@@ -13,12 +13,13 @@
  *     See the License for the specific language governing permissions and
  *     limitations under the License.
  */
+
 package org.springframework.integration.samples.storedprocedure.service;
 
 import java.util.List;
 
-import org.springframework.integration.annotation.Payload;
 import org.springframework.integration.samples.storedprocedure.model.CoffeeBeverage;
+import org.springframework.messaging.handler.annotation.Payload;
 
 
 /**
@@ -32,7 +33,7 @@ public interface CoffeeService {
     /**
      * Find the description for a provided coffee beverage.
      *
-     * @param Id of the coffee beverage
+     * @param input of the coffee beverage
      * @return The the description of the coffee beverage
      */
 	String findCoffeeBeverage(Integer input);

--- a/intermediate/stored-procedures-oracle/src/main/java/org/springframework/integration/samples/storedprocedure/service/CoffeeService.java
+++ b/intermediate/stored-procedures-oracle/src/main/java/org/springframework/integration/samples/storedprocedure/service/CoffeeService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2012 the original author or authors
+ * Copyright 2002-2014 the original author or authors
  *
  *     Licensed under the Apache License, Version 2.0 (the "License");
  *     you may not use this file except in compliance with the License.
@@ -13,12 +13,13 @@
  *     See the License for the specific language governing permissions and
  *     limitations under the License.
  */
+
 package org.springframework.integration.samples.storedprocedure.service;
 
 import java.util.List;
 
-import org.springframework.integration.annotation.Payload;
 import org.springframework.integration.samples.storedprocedure.model.CoffeeBeverage;
+import org.springframework.messaging.handler.annotation.Payload;
 import org.springframework.transaction.annotation.Transactional;
 
 
@@ -34,7 +35,7 @@ public interface CoffeeService {
 	/**
 	 * Find the description for a provided coffee beverage.
 	 *
-	 * @param Id of the coffee beverage
+	 * @param input of the coffee beverage
 	 * @return The the description of the coffee beverage
 	 */
 	String findCoffeeBeverage(Integer input);

--- a/intermediate/stored-procedures-postgresql/src/main/java/org/springframework/integration/samples/storedprocedure/service/CoffeeService.java
+++ b/intermediate/stored-procedures-postgresql/src/main/java/org/springframework/integration/samples/storedprocedure/service/CoffeeService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2012 the original author or authors
+ * Copyright 2002-2014 the original author or authors
  *
  *     Licensed under the Apache License, Version 2.0 (the "License");
  *     you may not use this file except in compliance with the License.
@@ -13,12 +13,13 @@
  *     See the License for the specific language governing permissions and
  *     limitations under the License.
  */
+
 package org.springframework.integration.samples.storedprocedure.service;
 
 import java.util.List;
 
-import org.springframework.integration.annotation.Payload;
 import org.springframework.integration.samples.storedprocedure.model.CoffeeBeverage;
+import org.springframework.messaging.handler.annotation.Payload;
 import org.springframework.transaction.annotation.Transactional;
 
 
@@ -34,7 +35,7 @@ public interface CoffeeService {
 	/**
 	 * Find the description for a provided coffee beverage.
 	 *
-	 * @param Id of the coffee beverage
+	 * @param input of the coffee beverage
 	 * @return The the description of the coffee beverage
 	 */
 	String findCoffeeBeverage(Integer input);


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INTSAMPLES-138
- Upgrade to Boot 1.2, which is based on the SI 4.1
- Upgrade to SF 4.1.1
- Fix `feed` sample to use new `Rome` dep. from SI
- Fix deprecations for `@Payload`, `@Header` etc.
- Fix mongo` sample deprecation warn
