### PR TITLE
Add specific slf4j version dependency

### DIFF
--- a/basic/ftp/pom.xml
+++ b/basic/ftp/pom.xml
@@ -102,6 +102,12 @@
       <scope>compile</scope>
     </dependency>
     <dependency>
+          <groupId>org.slf4j</groupId>
+          <artifactId>slf4j-api</artifactId>
+          <version>1.7.11</version>
+          <scope>compile</scope>
+      </dependency>
+    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-log4j12</artifactId>
       <version>1.7.11</version>


### PR DESCRIPTION
When just importing the ftp example as a maven project, I ran into the issue of a slf4j version discrepancy described here:
http://www.slf4j.org/faq.html#IllegalAccessError

This is solved by adding the specific version dependency of slf4j-api.