### PR TITLE
add cafe-dsl run task

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -664,6 +664,11 @@ project('cafe-dsl') {
 	springBoot {
 		mainClass = 'org.springframework.integration.samples.dsl.cafe.lambda.Application'
 	}
+	
+	task run(type: JavaExec) {
+		main 'org.springframework.integration.samples.dsl.cafe.nonlambda.Application'
+		classpath = sourceSets.main.runtimeClasspath
+	}
 }
 
 


### PR DESCRIPTION
Hi, 
in the cafe-DSL's readme there is written that for launch example is possible to type  'gradlew :cafe-dsl:run' but at the moment there is no task in the build.gradle
I don't open a jira cause i consider a trivial issue 

Thanks