### PR TITLE
Updated ws-outbound-gateway sample to reflect w3schools sample webservice has a new url

### DIFF
--- a/basic/ws-outbound-gateway/src/main/java/org/springframework/integration/samples/ws/WebServiceDemoTestApp.java
+++ b/basic/ws-outbound-gateway/src/main/java/org/springframework/integration/samples/ws/WebServiceDemoTestApp.java
@@ -39,7 +39,7 @@ public class WebServiceDemoTestApp {
 
 		// Compose the XML message according to the server's schema
 		String requestXml =
-				"<FahrenheitToCelsius xmlns=\"http://www.w3schools.com/webservices/\">" +
+				"<FahrenheitToCelsius xmlns=\"http://www.w3schools.com/xml/\">" +
 						"<Fahrenheit>90.0</Fahrenheit>" +
 				"</FahrenheitToCelsius>";
 

--- a/basic/ws-outbound-gateway/src/main/resources/META-INF/spring/integration/temperatureConversion.xml
+++ b/basic/ws-outbound-gateway/src/main/resources/META-INF/spring/integration/temperatureConversion.xml
@@ -18,9 +18,9 @@
 	     Web Service for the given URI, and the reply Message is sent to the 'celsiusChannel'. -->
 	<chain input-channel="fahrenheitChannel" output-channel="celsiusChannel">
 		<ws:header-enricher>
-			<ws:soap-action value="http://www.w3schools.com/webservices/FahrenheitToCelsius"/>
+			<ws:soap-action value="http://www.w3schools.com/xml/FahrenheitToCelsius"/>
 		</ws:header-enricher>
-		<ws:outbound-gateway uri="http://www.w3schools.com/webservices/tempconvert.asmx"/>
+		<ws:outbound-gateway uri="http://www.w3schools.com/xml/tempconvert.asmx"/>
 	</chain>
 
 	<!-- The response from the service is logged to the console. -->


### PR DESCRIPTION
w3schools moved their sample webservice application from http://www.w3schools.com/webservices/tempconvert.asmx to http://www.w3schools.com/xml/tempconvert.asmx"

I've updated the outbound sample application to reflect that change.

I have signed and agree to the terms of the Spring Individual Contributor
License Agreement.