### PR TITLE
Revert usage for `fileNameExpression`

### DIFF
--- a/advanced/dynamic-tcp-client/pom.xml
+++ b/advanced/dynamic-tcp-client/pom.xml
@@ -71,7 +71,7 @@
     <dependency>
       <groupId>org.springframework.integration</groupId>
       <artifactId>spring-integration-java-dsl</artifactId>
-      <version>1.2.0.RC1</version>
+      <version>1.2.0.RELEASE</version>
       <scope>compile</scope>
     </dependency>
     <dependency>

--- a/applications/file-split-ftp/pom.xml
+++ b/applications/file-split-ftp/pom.xml
@@ -94,7 +94,7 @@
     <dependency>
       <groupId>org.springframework.integration</groupId>
       <artifactId>spring-integration-java-dsl</artifactId>
-      <version>1.2.0.RC1</version>
+      <version>1.2.0.RELEASE</version>
       <scope>compile</scope>
     </dependency>
     <dependency>

--- a/applications/file-split-ftp/src/main/java/org/springframework/integration/samples/filesplit/Application.java
+++ b/applications/file-split-ftp/src/main/java/org/springframework/integration/samples/filesplit/Application.java
@@ -31,6 +31,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.integration.dsl.IntegrationFlow;
 import org.springframework.integration.dsl.IntegrationFlows;
 import org.springframework.integration.dsl.core.Pollers;
+import org.springframework.integration.dsl.file.FileWritingMessageHandlerSpec;
 import org.springframework.integration.dsl.file.Files;
 import org.springframework.integration.dsl.mail.Mail;
 import org.springframework.integration.file.FileHeaders;
@@ -62,7 +63,7 @@ public class Application {
 
 	/**
 	 * Poll for files, add an error channel, split into lines route the start/end markers
-	 * to {@link #markers()} and the lines to {@link #lines()}.
+	 * to {@link #markers()} and the lines to {@link #lines}.
 	 * @return the flow.
 	 */
 	@Bean
@@ -84,17 +85,16 @@ public class Application {
 	 * @return the flow.
 	 */
 	@Bean
-	public IntegrationFlow lines() {
-		return f -> f.handle(fileOut());
+	public IntegrationFlow lines(FileWritingMessageHandler fileOut) {
+		return f -> f.handle(fileOut);
 	}
 
 	@Bean
-	public FileWritingMessageHandler fileOut() {
+	public FileWritingMessageHandlerSpec fileOut() {
 		return Files.outboundAdapter("'/tmp/out'")
 				.appendNewLine(true)
-				.fileNameGenerator(m -> m.getPayload().toString().substring(1, 4) + ".txt")
-				.fileExistsMode(FileExistsMode.APPEND_NO_FLUSH) // files remain open for efficiency
-				.get();
+				.fileNameExpression("payload.substring(1, 4) + '.txt'")
+				.fileExistsMode(FileExistsMode.APPEND_NO_FLUSH); // files remain open for efficiency
 	}
 
 	/**

--- a/basic/mqtt/pom.xml
+++ b/basic/mqtt/pom.xml
@@ -77,7 +77,7 @@
     <dependency>
       <groupId>org.springframework.integration</groupId>
       <artifactId>spring-integration-java-dsl</artifactId>
-      <version>1.2.0.RC1</version>
+      <version>1.2.0.RELEASE</version>
       <scope>compile</scope>
     </dependency>
     <dependency>

--- a/dsl/cafe-dsl/pom.xml
+++ b/dsl/cafe-dsl/pom.xml
@@ -83,7 +83,7 @@
     <dependency>
       <groupId>org.springframework.integration</groupId>
       <artifactId>spring-integration-java-dsl</artifactId>
-      <version>1.2.0.RC1</version>
+      <version>1.2.0.RELEASE</version>
       <scope>compile</scope>
     </dependency>
     <dependency>

--- a/dsl/kafka-dsl/pom.xml
+++ b/dsl/kafka-dsl/pom.xml
@@ -71,7 +71,7 @@
     <dependency>
       <groupId>org.springframework.integration</groupId>
       <artifactId>spring-integration-java-dsl</artifactId>
-      <version>1.2.0.RC1</version>
+      <version>1.2.0.RELEASE</version>
       <scope>compile</scope>
     </dependency>
     <dependency>

--- a/dsl/si4demo/pom.xml
+++ b/dsl/si4demo/pom.xml
@@ -90,7 +90,7 @@
     <dependency>
       <groupId>org.springframework.integration</groupId>
       <artifactId>spring-integration-java-dsl</artifactId>
-      <version>1.2.0.RC1</version>
+      <version>1.2.0.RELEASE</version>
       <scope>compile</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
Since we provide a custom `FileNameGenerator` via `fileNameExpression` we should ensure somehow `BeanFactory` injection to that
`FileWritingMessageHandlerSpec` is a `FactoryBean` since version DSL `1.2` and a particular `BPP` takes care about `Spec` internals and register custom `FileNameGenerator` as a bean.

 Use standard `FactoryBean` injection in the `lines()` flow to populate the target `FileWritingMessageHandler` to the flow
Generate pom for all project to apply SI Java DSL 1.2 GA