### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,11 +120,11 @@ This category targets developers and architects who have a good understanding of
 * **loanshark** This extension to the loan broker sample shows how to exchange messages between Spring Integration applications (and other technologies) using **UDP**.
   **file-split-ftp** - Reads a file; splits into 3 based on contents; sends files over ftp; sends email with results.
 
-#Contributing
+# Contributing
 
 See the [Spring Integration Contributor Guidelines](https://github.com/spring-projects/spring-integration/blob/master/CONTRIBUTING.adoc) for information about how to contribute to this repository.
 
-#Resources
+# Resources
 
 For more information, please visit the Spring Integration website at: [http://projects.spring.io/spring-integration/](http://projects.spring.io/spring-integration/)
 

--- a/dsl/cafe-dsl/README.md
+++ b/dsl/cafe-dsl/README.md
@@ -1,4 +1,4 @@
-#Cafe Demo: Spring Integration Java DSL
+# Cafe Demo: Spring Integration Java DSL
 
 This sample demonstrates the classical Cafe Demo, but it is based on [Spring Integration Java DSL](https://github.com/spring-projects/spring-integration-extensions/wiki/Spring-Integration-Java-DSL-Reference)
  and [Spring Boot](http://projects.spring.io/spring-boot).

--- a/dsl/si4demo/README.md
+++ b/dsl/si4demo/README.md
@@ -1,4 +1,4 @@
-#Spring Integration 4.0/4.1 Java Config/DSL Demo
+# Spring Integration 4.0/4.1 Java Config/DSL Demo
 
 This sample is the demo used in the [Spring Integration 4.0 Webinar](https://spring.io/blog/2014/05/15/webinar-replay-spring-integration-4-0-the-new-frontier) and SpringOne/2GX 2014.
 
@@ -36,13 +36,13 @@ Twitter now requires authentication to perform searches; visit the [twitter deve
 
 
 
-#SpringOne/2GX 2014
+# SpringOne/2GX 2014
 
 Additional examples were added to this project at __SpringOne2GX 2014__ - see the __springone__ package.
 
 This demonstrates moving from completely XML configuration, through Java Configuration, and ultimately to the DSL.
 
-##AXML
+## AXML
 
 This example is pure XML - it's a simple flow...
 
@@ -50,15 +50,15 @@ This example is pure XML - it's a simple flow...
 
 The transformer concatentates the payload to itself (String), the service upper cases the payload. The result is returned to the gateway. "foo" becomes "FOOFOO".
 
-##BXMLAndPojo
+## BXMLAndPojo
 
 This takes the same example and shows how to configure it using "classic" Spring Integration annotations, available since 2.0.
 
-##CNoXML
+## CNoXML
 
 This takes the same example and configures it using standard Java Configuration (available since 4.0). Many of the standard annotations are now available on __@Bean__ definitions; note that the output channel must be configured on the handler, not the annotation. __@IntegrationComponentScan__ detects __@MessagingGateway__ interfaces and creates gateways.
 
-##DBoot
+## DBoot
 
 This takes the same example as __C...__ and configures it using Spring Boot. The configuration is slightly more concise.
 
@@ -68,15 +68,15 @@ Note: Other applications in this project use the embedded web server (for http a
 					.web(false)
 					.run(args);
 
-##EDSL
+## EDSL
 
 This takes the same example and configures it using the Spring Integration Java DSL. It requires Spring Integration 4.1.0.M1 and DSL 1.0.0.M3.
 
-##FMail
+## FMail
 
 This adds a recipient list router and sends a copy of the payload to an SMTP Email server (add credentials to __application.yml__).
 
-##GIMAP
+## GIMAP
 
 This is a separate application that demonstrates the DSL configuring an IMAP idle channel adapter, to receive emails sent by __FEmail__.
 

--- a/intermediate/retry-and-more/README.md
+++ b/intermediate/retry-and-more/README.md
@@ -4,7 +4,7 @@ Handler Advice Sample "retry-and-more"
 This sample shows how to use the 2.2.0 Handler Advice feature.
 
 
-##Stateless Retry Advice Demo
+## Stateless Retry Advice Demo
 
 This class (`StatelessRetryDemo`) demonstrates stateless retry.
 
@@ -24,7 +24,7 @@ __NOTE: Starting with Spring Integration 4.0, stateless retry has convenient nam
 It shows the retry advice declared (for each profile) as a top level bean `<int:handler-retry-advice id="retryAdvice">`. Declaring it as a top level bean allows it to be used in multiple places (or via profiles). You can also declare it within the advice chain using `<int:retry-advice/>` (with no 'id'). In that case, it cannot be reused in other advice chains.
 
 
-##Stateful Retry Advice Demo
+## Stateful Retry Advice Demo
 
 This class (`StatefulRetryDemo`) demonstrates stateful retry.
 
@@ -32,7 +32,7 @@ It is similar to the default version of the stateless retry but uses AMQP; you w
 
 NOTE: Starting with Spring Integration 4.0, __stateless retry__ has convenient namespace support; stateful retry requires the retry advice to be configured using `<bean/>` definitions as is shown here.
 
-##Circuit Breaker Advice Demo
+## Circuit Breaker Advice Demo
 
 This class (`CircuitBreakerDemo`) demonstrates the circuit breaker advice.
 
@@ -41,7 +41,7 @@ In this demo, the target service only succeeds in the last quarter of any minute
 You can observe the function of the advice by entering a number of messages over time, and watch the resulting messages.
 
 
-##Expression Evaluating Advice Demo
+## Expression Evaluating Advice Demo
 
 `FileTransferDeleteAfterSuccessDemo`
 
@@ -61,6 +61,6 @@ No real FTP is involved; mocks are used to simulate the transfer (success or fai
 In both cases simply add a file ending with .txt in ${java.io.tmpdir}/adviceDemo (e.g. touch /tmp/adviceDemo/x,txt) and the results will appear in the console.
 
 
-##Running the Demos
+## Running the Demos
 
 In each case, run the main method in each of the demonstration classes.


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
