### PR TITLE
URL Cleanup

### DIFF
--- a/advanced/advanced-testing-examples/pom.xml
+++ b/advanced/advanced-testing-examples/pom.xml
@@ -6,7 +6,7 @@
   <version>5.1.1.BUILD-SNAPSHOT</version>
   <name>Advanced Testing Examples</name>
   <description>Advanced Testing Examples</description>
-  <url>http://projects.spring.io/spring-integration</url>
+  <url>https://projects.spring.io/spring-integration</url>
   <organization>
     <name>SpringIO</name>
     <url>https://spring.io</url>
@@ -14,7 +14,7 @@
   <licenses>
     <license>
       <name>The Apache Software License, Version 2.0</name>
-      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
       <distribution>repo</distribution>
     </license>
   </licenses>

--- a/advanced/dynamic-ftp/pom.xml
+++ b/advanced/dynamic-ftp/pom.xml
@@ -6,7 +6,7 @@
   <version>5.1.1.BUILD-SNAPSHOT</version>
   <name>Dynamic FTP Demo</name>
   <description>Dynamic FTP Demo</description>
-  <url>http://projects.spring.io/spring-integration</url>
+  <url>https://projects.spring.io/spring-integration</url>
   <organization>
     <name>SpringIO</name>
     <url>https://spring.io</url>
@@ -14,7 +14,7 @@
   <licenses>
     <license>
       <name>The Apache Software License, Version 2.0</name>
-      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
       <distribution>repo</distribution>
     </license>
   </licenses>

--- a/advanced/dynamic-tcp-client/pom.xml
+++ b/advanced/dynamic-tcp-client/pom.xml
@@ -11,7 +11,7 @@
   <version>5.1.1.BUILD-SNAPSHOT</version>
   <name>Dynamic TCP Client</name>
   <description>Dynamic TCP Client</description>
-  <url>http://projects.spring.io/spring-integration</url>
+  <url>https://projects.spring.io/spring-integration</url>
   <organization>
     <name>SpringIO</name>
     <url>https://spring.io</url>
@@ -19,7 +19,7 @@
   <licenses>
     <license>
       <name>The Apache Software License, Version 2.0</name>
-      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
       <distribution>repo</distribution>
     </license>
   </licenses>

--- a/advanced/pom.xml
+++ b/advanced/pom.xml
@@ -5,7 +5,7 @@
   <groupId>org.springframework.integration.samples</groupId>
   <artifactId>advanced</artifactId>
   <version>5.1.1.BUILD-SNAPSHOT</version>
-  <url>http://projects.spring.io/spring-integration</url>
+  <url>https://projects.spring.io/spring-integration</url>
   <organization>
     <name>SpringIO</name>
     <url>https://spring.io</url>
@@ -13,7 +13,7 @@
   <licenses>
     <license>
       <name>The Apache Software License, Version 2.0</name>
-      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
       <distribution>repo</distribution>
     </license>
   </licenses>

--- a/applications/cafe-scripted/pom.xml
+++ b/applications/cafe-scripted/pom.xml
@@ -6,7 +6,7 @@
   <version>5.1.1.BUILD-SNAPSHOT</version>
   <name>Cafe Sample (Scripted Implementation)</name>
   <description>Cafe Sample (Scripted Implementation)</description>
-  <url>http://projects.spring.io/spring-integration</url>
+  <url>https://projects.spring.io/spring-integration</url>
   <organization>
     <name>SpringIO</name>
     <url>https://spring.io</url>
@@ -14,7 +14,7 @@
   <licenses>
     <license>
       <name>The Apache Software License, Version 2.0</name>
-      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
       <distribution>repo</distribution>
     </license>
   </licenses>

--- a/applications/cafe/cafe-amqp/pom.xml
+++ b/applications/cafe/cafe-amqp/pom.xml
@@ -6,7 +6,7 @@
   <version>5.1.1.BUILD-SNAPSHOT</version>
   <name>Cafe - With AMQP Message Broker</name>
   <description>Cafe - With AMQP Message Broker</description>
-  <url>http://projects.spring.io/spring-integration</url>
+  <url>https://projects.spring.io/spring-integration</url>
   <organization>
     <name>SpringIO</name>
     <url>https://spring.io</url>
@@ -14,7 +14,7 @@
   <licenses>
     <license>
       <name>The Apache Software License, Version 2.0</name>
-      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
       <distribution>repo</distribution>
     </license>
   </licenses>

--- a/applications/cafe/cafe-jms/pom.xml
+++ b/applications/cafe/cafe-jms/pom.xml
@@ -6,7 +6,7 @@
   <version>5.1.1.BUILD-SNAPSHOT</version>
   <name>Cafe - With JMS Message Broker</name>
   <description>Cafe - With JMS Message Broker</description>
-  <url>http://projects.spring.io/spring-integration</url>
+  <url>https://projects.spring.io/spring-integration</url>
   <organization>
     <name>SpringIO</name>
     <url>https://spring.io</url>
@@ -14,7 +14,7 @@
   <licenses>
     <license>
       <name>The Apache Software License, Version 2.0</name>
-      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
       <distribution>repo</distribution>
     </license>
   </licenses>

--- a/applications/cafe/cafe-si/pom.xml
+++ b/applications/cafe/cafe-si/pom.xml
@@ -6,7 +6,7 @@
   <version>5.1.1.BUILD-SNAPSHOT</version>
   <name>Cafe - Pure Spring Integration</name>
   <description>Cafe - Pure Spring Integration</description>
-  <url>http://projects.spring.io/spring-integration</url>
+  <url>https://projects.spring.io/spring-integration</url>
   <organization>
     <name>SpringIO</name>
     <url>https://spring.io</url>
@@ -14,7 +14,7 @@
   <licenses>
     <license>
       <name>The Apache Software License, Version 2.0</name>
-      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
       <distribution>repo</distribution>
     </license>
   </licenses>

--- a/applications/cafe/pom.xml
+++ b/applications/cafe/pom.xml
@@ -5,7 +5,7 @@
   <groupId>org.springframework.integration.samples</groupId>
   <artifactId>cafe</artifactId>
   <version>5.1.1.BUILD-SNAPSHOT</version>
-  <url>http://projects.spring.io/spring-integration</url>
+  <url>https://projects.spring.io/spring-integration</url>
   <organization>
     <name>SpringIO</name>
     <url>https://spring.io</url>
@@ -13,7 +13,7 @@
   <licenses>
     <license>
       <name>The Apache Software License, Version 2.0</name>
-      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
       <distribution>repo</distribution>
     </license>
   </licenses>

--- a/applications/file-split-ftp/pom.xml
+++ b/applications/file-split-ftp/pom.xml
@@ -11,7 +11,7 @@
   <version>5.1.1.BUILD-SNAPSHOT</version>
   <name>File Split FTP</name>
   <description>File Split FTP</description>
-  <url>http://projects.spring.io/spring-integration</url>
+  <url>https://projects.spring.io/spring-integration</url>
   <organization>
     <name>SpringIO</name>
     <url>https://spring.io</url>
@@ -19,7 +19,7 @@
   <licenses>
     <license>
       <name>The Apache Software License, Version 2.0</name>
-      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
       <distribution>repo</distribution>
     </license>
   </licenses>

--- a/applications/loan-broker/pom.xml
+++ b/applications/loan-broker/pom.xml
@@ -6,7 +6,7 @@
   <version>5.1.1.BUILD-SNAPSHOT</version>
   <name>Loan Broker Sample</name>
   <description>Loan Broker Sample</description>
-  <url>http://projects.spring.io/spring-integration</url>
+  <url>https://projects.spring.io/spring-integration</url>
   <organization>
     <name>SpringIO</name>
     <url>https://spring.io</url>
@@ -14,7 +14,7 @@
   <licenses>
     <license>
       <name>The Apache Software License, Version 2.0</name>
-      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
       <distribution>repo</distribution>
     </license>
   </licenses>

--- a/applications/loanshark/pom.xml
+++ b/applications/loanshark/pom.xml
@@ -6,7 +6,7 @@
   <version>5.1.1.BUILD-SNAPSHOT</version>
   <name>Loan Shark Sample</name>
   <description>Loan Shark Sample</description>
-  <url>http://projects.spring.io/spring-integration</url>
+  <url>https://projects.spring.io/spring-integration</url>
   <organization>
     <name>SpringIO</name>
     <url>https://spring.io</url>
@@ -14,7 +14,7 @@
   <licenses>
     <license>
       <name>The Apache Software License, Version 2.0</name>
-      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
       <distribution>repo</distribution>
     </license>
   </licenses>

--- a/applications/pom.xml
+++ b/applications/pom.xml
@@ -5,7 +5,7 @@
   <groupId>org.springframework.integration.samples</groupId>
   <artifactId>applications</artifactId>
   <version>5.1.1.BUILD-SNAPSHOT</version>
-  <url>http://projects.spring.io/spring-integration</url>
+  <url>https://projects.spring.io/spring-integration</url>
   <organization>
     <name>SpringIO</name>
     <url>https://spring.io</url>
@@ -13,7 +13,7 @@
   <licenses>
     <license>
       <name>The Apache Software License, Version 2.0</name>
-      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
       <distribution>repo</distribution>
     </license>
   </licenses>

--- a/applications/stomp-chat/pom.xml
+++ b/applications/stomp-chat/pom.xml
@@ -11,7 +11,7 @@
   <version>5.1.1.BUILD-SNAPSHOT</version>
   <name>Web Sockets Stomp Chat Sample</name>
   <description>Web Sockets Stomp Chat Sample</description>
-  <url>http://projects.spring.io/spring-integration</url>
+  <url>https://projects.spring.io/spring-integration</url>
   <organization>
     <name>SpringIO</name>
     <url>https://spring.io</url>
@@ -19,7 +19,7 @@
   <licenses>
     <license>
       <name>The Apache Software License, Version 2.0</name>
-      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
       <distribution>repo</distribution>
     </license>
   </licenses>

--- a/basic/amqp/pom.xml
+++ b/basic/amqp/pom.xml
@@ -6,7 +6,7 @@
   <version>5.1.1.BUILD-SNAPSHOT</version>
   <name>AMQP Basic Sample</name>
   <description>AMQP Basic Sample</description>
-  <url>http://projects.spring.io/spring-integration</url>
+  <url>https://projects.spring.io/spring-integration</url>
   <organization>
     <name>SpringIO</name>
     <url>https://spring.io</url>
@@ -14,7 +14,7 @@
   <licenses>
     <license>
       <name>The Apache Software License, Version 2.0</name>
-      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
       <distribution>repo</distribution>
     </license>
   </licenses>

--- a/basic/barrier/pom.xml
+++ b/basic/barrier/pom.xml
@@ -11,7 +11,7 @@
   <version>5.1.1.BUILD-SNAPSHOT</version>
   <name>Barrier Sample</name>
   <description>Barrier Sample</description>
-  <url>http://projects.spring.io/spring-integration</url>
+  <url>https://projects.spring.io/spring-integration</url>
   <organization>
     <name>SpringIO</name>
     <url>https://spring.io</url>
@@ -19,7 +19,7 @@
   <licenses>
     <license>
       <name>The Apache Software License, Version 2.0</name>
-      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
       <distribution>repo</distribution>
     </license>
   </licenses>

--- a/basic/control-bus/pom.xml
+++ b/basic/control-bus/pom.xml
@@ -6,7 +6,7 @@
   <version>5.1.1.BUILD-SNAPSHOT</version>
   <name>Control Bus Basic Sample</name>
   <description>Control Bus Basic Sample</description>
-  <url>http://projects.spring.io/spring-integration</url>
+  <url>https://projects.spring.io/spring-integration</url>
   <organization>
     <name>SpringIO</name>
     <url>https://spring.io</url>
@@ -14,7 +14,7 @@
   <licenses>
     <license>
       <name>The Apache Software License, Version 2.0</name>
-      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
       <distribution>repo</distribution>
     </license>
   </licenses>

--- a/basic/enricher/pom.xml
+++ b/basic/enricher/pom.xml
@@ -6,7 +6,7 @@
   <version>5.1.1.BUILD-SNAPSHOT</version>
   <name>Enricher Basic Sample</name>
   <description>Enricher Basic Sample</description>
-  <url>http://projects.spring.io/spring-integration</url>
+  <url>https://projects.spring.io/spring-integration</url>
   <organization>
     <name>SpringIO</name>
     <url>https://spring.io</url>
@@ -14,7 +14,7 @@
   <licenses>
     <license>
       <name>The Apache Software License, Version 2.0</name>
-      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
       <distribution>repo</distribution>
     </license>
   </licenses>

--- a/basic/feed/pom.xml
+++ b/basic/feed/pom.xml
@@ -6,7 +6,7 @@
   <version>5.1.1.BUILD-SNAPSHOT</version>
   <name>Feed (RSS/ATOM) Basic Sample</name>
   <description>Feed (RSS/ATOM) Basic Sample</description>
-  <url>http://projects.spring.io/spring-integration</url>
+  <url>https://projects.spring.io/spring-integration</url>
   <organization>
     <name>SpringIO</name>
     <url>https://spring.io</url>
@@ -14,7 +14,7 @@
   <licenses>
     <license>
       <name>The Apache Software License, Version 2.0</name>
-      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
       <distribution>repo</distribution>
     </license>
   </licenses>

--- a/basic/file/pom.xml
+++ b/basic/file/pom.xml
@@ -6,7 +6,7 @@
   <version>5.1.1.BUILD-SNAPSHOT</version>
   <name>File Copy Basic Sample</name>
   <description>File Copy Basic Sample</description>
-  <url>http://projects.spring.io/spring-integration</url>
+  <url>https://projects.spring.io/spring-integration</url>
   <organization>
     <name>SpringIO</name>
     <url>https://spring.io</url>
@@ -14,7 +14,7 @@
   <licenses>
     <license>
       <name>The Apache Software License, Version 2.0</name>
-      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
       <distribution>repo</distribution>
     </license>
   </licenses>

--- a/basic/ftp/pom.xml
+++ b/basic/ftp/pom.xml
@@ -6,7 +6,7 @@
   <version>5.1.1.BUILD-SNAPSHOT</version>
   <name>FTP Basic Sample</name>
   <description>FTP Basic Sample</description>
-  <url>http://projects.spring.io/spring-integration</url>
+  <url>https://projects.spring.io/spring-integration</url>
   <organization>
     <name>SpringIO</name>
     <url>https://spring.io</url>
@@ -14,7 +14,7 @@
   <licenses>
     <license>
       <name>The Apache Software License, Version 2.0</name>
-      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
       <distribution>repo</distribution>
     </license>
   </licenses>

--- a/basic/helloworld/pom.xml
+++ b/basic/helloworld/pom.xml
@@ -6,7 +6,7 @@
   <version>5.1.1.BUILD-SNAPSHOT</version>
   <name>Hello World Sample</name>
   <description>Hello World Sample</description>
-  <url>http://projects.spring.io/spring-integration</url>
+  <url>https://projects.spring.io/spring-integration</url>
   <organization>
     <name>SpringIO</name>
     <url>https://spring.io</url>
@@ -14,7 +14,7 @@
   <licenses>
     <license>
       <name>The Apache Software License, Version 2.0</name>
-      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
       <distribution>repo</distribution>
     </license>
   </licenses>

--- a/basic/http/pom.xml
+++ b/basic/http/pom.xml
@@ -6,7 +6,7 @@
   <version>5.1.1.BUILD-SNAPSHOT</version>
   <name>HTTP Sample</name>
   <description>HTTP Sample</description>
-  <url>http://projects.spring.io/spring-integration</url>
+  <url>https://projects.spring.io/spring-integration</url>
   <organization>
     <name>SpringIO</name>
     <url>https://spring.io</url>
@@ -14,7 +14,7 @@
   <licenses>
     <license>
       <name>The Apache Software License, Version 2.0</name>
-      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
       <distribution>repo</distribution>
     </license>
   </licenses>

--- a/basic/jdbc/pom.xml
+++ b/basic/jdbc/pom.xml
@@ -6,7 +6,7 @@
   <version>5.1.1.BUILD-SNAPSHOT</version>
   <name>JDBC Basic Sample</name>
   <description>JDBC Basic Sample</description>
-  <url>http://projects.spring.io/spring-integration</url>
+  <url>https://projects.spring.io/spring-integration</url>
   <organization>
     <name>SpringIO</name>
     <url>https://spring.io</url>
@@ -14,7 +14,7 @@
   <licenses>
     <license>
       <name>The Apache Software License, Version 2.0</name>
-      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
       <distribution>repo</distribution>
     </license>
   </licenses>

--- a/basic/jms/pom.xml
+++ b/basic/jms/pom.xml
@@ -6,7 +6,7 @@
   <version>5.1.1.BUILD-SNAPSHOT</version>
   <name>JMS Basic Sample</name>
   <description>JMS Basic Sample</description>
-  <url>http://projects.spring.io/spring-integration</url>
+  <url>https://projects.spring.io/spring-integration</url>
   <organization>
     <name>SpringIO</name>
     <url>https://spring.io</url>
@@ -14,7 +14,7 @@
   <licenses>
     <license>
       <name>The Apache Software License, Version 2.0</name>
-      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
       <distribution>repo</distribution>
     </license>
   </licenses>

--- a/basic/jmx/pom.xml
+++ b/basic/jmx/pom.xml
@@ -6,7 +6,7 @@
   <version>5.1.1.BUILD-SNAPSHOT</version>
   <name>JMX Basic Sample</name>
   <description>JMX Basic Sample</description>
-  <url>http://projects.spring.io/spring-integration</url>
+  <url>https://projects.spring.io/spring-integration</url>
   <organization>
     <name>SpringIO</name>
     <url>https://spring.io</url>
@@ -14,7 +14,7 @@
   <licenses>
     <license>
       <name>The Apache Software License, Version 2.0</name>
-      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
       <distribution>repo</distribution>
     </license>
   </licenses>

--- a/basic/jpa/pom.xml
+++ b/basic/jpa/pom.xml
@@ -11,7 +11,7 @@
   <version>5.1.1.BUILD-SNAPSHOT</version>
   <name>JPA Basic Sample</name>
   <description>JPA Basic Sample</description>
-  <url>http://projects.spring.io/spring-integration</url>
+  <url>https://projects.spring.io/spring-integration</url>
   <organization>
     <name>SpringIO</name>
     <url>https://spring.io</url>
@@ -19,7 +19,7 @@
   <licenses>
     <license>
       <name>The Apache Software License, Version 2.0</name>
-      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
       <distribution>repo</distribution>
     </license>
   </licenses>

--- a/basic/kafka/pom.xml
+++ b/basic/kafka/pom.xml
@@ -11,7 +11,7 @@
   <version>5.1.1.BUILD-SNAPSHOT</version>
   <name>Apache Kafka Sample</name>
   <description>Apache Kafka Sample</description>
-  <url>http://projects.spring.io/spring-integration</url>
+  <url>https://projects.spring.io/spring-integration</url>
   <organization>
     <name>SpringIO</name>
     <url>https://spring.io</url>
@@ -19,7 +19,7 @@
   <licenses>
     <license>
       <name>The Apache Software License, Version 2.0</name>
-      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
       <distribution>repo</distribution>
     </license>
   </licenses>

--- a/basic/mail/pom.xml
+++ b/basic/mail/pom.xml
@@ -6,7 +6,7 @@
   <version>5.1.1.BUILD-SNAPSHOT</version>
   <name>Mail (IMAP + POP3) Sample</name>
   <description>Mail (IMAP + POP3) Sample</description>
-  <url>http://projects.spring.io/spring-integration</url>
+  <url>https://projects.spring.io/spring-integration</url>
   <organization>
     <name>SpringIO</name>
     <url>https://spring.io</url>
@@ -14,7 +14,7 @@
   <licenses>
     <license>
       <name>The Apache Software License, Version 2.0</name>
-      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
       <distribution>repo</distribution>
     </license>
   </licenses>

--- a/basic/mongodb/pom.xml
+++ b/basic/mongodb/pom.xml
@@ -6,7 +6,7 @@
   <version>5.1.1.BUILD-SNAPSHOT</version>
   <name>MongoDb Basic Sample</name>
   <description>MongoDb Basic Sample</description>
-  <url>http://projects.spring.io/spring-integration</url>
+  <url>https://projects.spring.io/spring-integration</url>
   <organization>
     <name>SpringIO</name>
     <url>https://spring.io</url>
@@ -14,7 +14,7 @@
   <licenses>
     <license>
       <name>The Apache Software License, Version 2.0</name>
-      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
       <distribution>repo</distribution>
     </license>
   </licenses>

--- a/basic/mqtt/pom.xml
+++ b/basic/mqtt/pom.xml
@@ -11,7 +11,7 @@
   <version>5.1.1.BUILD-SNAPSHOT</version>
   <name>MQTT Basic Sample</name>
   <description>MQTT Basic Sample</description>
-  <url>http://projects.spring.io/spring-integration</url>
+  <url>https://projects.spring.io/spring-integration</url>
   <organization>
     <name>SpringIO</name>
     <url>https://spring.io</url>
@@ -19,7 +19,7 @@
   <licenses>
     <license>
       <name>The Apache Software License, Version 2.0</name>
-      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
       <distribution>repo</distribution>
     </license>
   </licenses>

--- a/basic/oddeven/pom.xml
+++ b/basic/oddeven/pom.xml
@@ -6,7 +6,7 @@
   <version>5.1.1.BUILD-SNAPSHOT</version>
   <name>Odd-Even Sample</name>
   <description>Odd-Even Sample</description>
-  <url>http://projects.spring.io/spring-integration</url>
+  <url>https://projects.spring.io/spring-integration</url>
   <organization>
     <name>SpringIO</name>
     <url>https://spring.io</url>
@@ -14,7 +14,7 @@
   <licenses>
     <license>
       <name>The Apache Software License, Version 2.0</name>
-      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
       <distribution>repo</distribution>
     </license>
   </licenses>

--- a/basic/pom.xml
+++ b/basic/pom.xml
@@ -5,7 +5,7 @@
   <groupId>org.springframework.integration.samples</groupId>
   <artifactId>basic</artifactId>
   <version>5.1.1.BUILD-SNAPSHOT</version>
-  <url>http://projects.spring.io/spring-integration</url>
+  <url>https://projects.spring.io/spring-integration</url>
   <organization>
     <name>SpringIO</name>
     <url>https://spring.io</url>
@@ -13,7 +13,7 @@
   <licenses>
     <license>
       <name>The Apache Software License, Version 2.0</name>
-      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
       <distribution>repo</distribution>
     </license>
   </licenses>

--- a/basic/quote/pom.xml
+++ b/basic/quote/pom.xml
@@ -6,7 +6,7 @@
   <version>5.1.1.BUILD-SNAPSHOT</version>
   <name>Quote Sample</name>
   <description>Quote Sample</description>
-  <url>http://projects.spring.io/spring-integration</url>
+  <url>https://projects.spring.io/spring-integration</url>
   <organization>
     <name>SpringIO</name>
     <url>https://spring.io</url>
@@ -14,7 +14,7 @@
   <licenses>
     <license>
       <name>The Apache Software License, Version 2.0</name>
-      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
       <distribution>repo</distribution>
     </license>
   </licenses>

--- a/basic/sftp/pom.xml
+++ b/basic/sftp/pom.xml
@@ -6,7 +6,7 @@
   <version>5.1.1.BUILD-SNAPSHOT</version>
   <name>SFTP Basic Sample</name>
   <description>SFTP Basic Sample</description>
-  <url>http://projects.spring.io/spring-integration</url>
+  <url>https://projects.spring.io/spring-integration</url>
   <organization>
     <name>SpringIO</name>
     <url>https://spring.io</url>
@@ -14,7 +14,7 @@
   <licenses>
     <license>
       <name>The Apache Software License, Version 2.0</name>
-      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
       <distribution>repo</distribution>
     </license>
   </licenses>

--- a/basic/splunk/pom.xml
+++ b/basic/splunk/pom.xml
@@ -11,7 +11,7 @@
   <version>5.1.1.BUILD-SNAPSHOT</version>
   <name>Splunk Sample</name>
   <description>Splunk Sample</description>
-  <url>http://projects.spring.io/spring-integration</url>
+  <url>https://projects.spring.io/spring-integration</url>
   <organization>
     <name>SpringIO</name>
     <url>https://spring.io</url>
@@ -19,7 +19,7 @@
   <licenses>
     <license>
       <name>The Apache Software License, Version 2.0</name>
-      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
       <distribution>repo</distribution>
     </license>
   </licenses>

--- a/basic/tcp-amqp/pom.xml
+++ b/basic/tcp-amqp/pom.xml
@@ -6,7 +6,7 @@
   <version>5.1.1.BUILD-SNAPSHOT</version>
   <name>TCP-AMQP Basic Sample</name>
   <description>TCP-AMQP Basic Sample</description>
-  <url>http://projects.spring.io/spring-integration</url>
+  <url>https://projects.spring.io/spring-integration</url>
   <organization>
     <name>SpringIO</name>
     <url>https://spring.io</url>
@@ -14,7 +14,7 @@
   <licenses>
     <license>
       <name>The Apache Software License, Version 2.0</name>
-      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
       <distribution>repo</distribution>
     </license>
   </licenses>

--- a/basic/tcp-broadcast/pom.xml
+++ b/basic/tcp-broadcast/pom.xml
@@ -11,7 +11,7 @@
   <version>5.1.1.BUILD-SNAPSHOT</version>
   <name>TCP Client Broadcast Sample</name>
   <description>TCP Client Broadcast Sample</description>
-  <url>http://projects.spring.io/spring-integration</url>
+  <url>https://projects.spring.io/spring-integration</url>
   <organization>
     <name>SpringIO</name>
     <url>https://spring.io</url>
@@ -19,7 +19,7 @@
   <licenses>
     <license>
       <name>The Apache Software License, Version 2.0</name>
-      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
       <distribution>repo</distribution>
     </license>
   </licenses>

--- a/basic/tcp-client-server/pom.xml
+++ b/basic/tcp-client-server/pom.xml
@@ -6,7 +6,7 @@
   <version>5.1.1.BUILD-SNAPSHOT</version>
   <name>TCP Client Server Sample</name>
   <description>TCP Client Server Sample</description>
-  <url>http://projects.spring.io/spring-integration</url>
+  <url>https://projects.spring.io/spring-integration</url>
   <organization>
     <name>SpringIO</name>
     <url>https://spring.io</url>
@@ -14,7 +14,7 @@
   <licenses>
     <license>
       <name>The Apache Software License, Version 2.0</name>
-      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
       <distribution>repo</distribution>
     </license>
   </licenses>

--- a/basic/testing-examples/pom.xml
+++ b/basic/testing-examples/pom.xml
@@ -6,7 +6,7 @@
   <version>5.1.1.BUILD-SNAPSHOT</version>
   <name>Testing Examples</name>
   <description>Testing Examples</description>
-  <url>http://projects.spring.io/spring-integration</url>
+  <url>https://projects.spring.io/spring-integration</url>
   <organization>
     <name>SpringIO</name>
     <url>https://spring.io</url>
@@ -14,7 +14,7 @@
   <licenses>
     <license>
       <name>The Apache Software License, Version 2.0</name>
-      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
       <distribution>repo</distribution>
     </license>
   </licenses>

--- a/basic/twitter/pom.xml
+++ b/basic/twitter/pom.xml
@@ -6,7 +6,7 @@
   <version>5.1.1.BUILD-SNAPSHOT</version>
   <name>Twitter Basic Sample</name>
   <description>Twitter Basic Sample</description>
-  <url>http://projects.spring.io/spring-integration</url>
+  <url>https://projects.spring.io/spring-integration</url>
   <organization>
     <name>SpringIO</name>
     <url>https://spring.io</url>
@@ -14,7 +14,7 @@
   <licenses>
     <license>
       <name>The Apache Software License, Version 2.0</name>
-      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
       <distribution>repo</distribution>
     </license>
   </licenses>

--- a/basic/web-sockets/pom.xml
+++ b/basic/web-sockets/pom.xml
@@ -11,7 +11,7 @@
   <version>5.1.1.BUILD-SNAPSHOT</version>
   <name>Web Sockets Basic Sample</name>
   <description>Web Sockets Basic Sample</description>
-  <url>http://projects.spring.io/spring-integration</url>
+  <url>https://projects.spring.io/spring-integration</url>
   <organization>
     <name>SpringIO</name>
     <url>https://spring.io</url>
@@ -19,7 +19,7 @@
   <licenses>
     <license>
       <name>The Apache Software License, Version 2.0</name>
-      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
       <distribution>repo</distribution>
     </license>
   </licenses>

--- a/basic/ws-inbound-gateway/pom.xml
+++ b/basic/ws-inbound-gateway/pom.xml
@@ -6,7 +6,7 @@
   <version>5.1.1.BUILD-SNAPSHOT</version>
   <name>WS Inbound Gateway Sample</name>
   <description>WS Inbound Gateway Sample</description>
-  <url>http://projects.spring.io/spring-integration</url>
+  <url>https://projects.spring.io/spring-integration</url>
   <organization>
     <name>SpringIO</name>
     <url>https://spring.io</url>
@@ -14,7 +14,7 @@
   <licenses>
     <license>
       <name>The Apache Software License, Version 2.0</name>
-      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
       <distribution>repo</distribution>
     </license>
   </licenses>

--- a/basic/ws-outbound-gateway/pom.xml
+++ b/basic/ws-outbound-gateway/pom.xml
@@ -6,7 +6,7 @@
   <version>5.1.1.BUILD-SNAPSHOT</version>
   <name>WS Outbound Gateway Sample</name>
   <description>WS Outbound Gateway Sample</description>
-  <url>http://projects.spring.io/spring-integration</url>
+  <url>https://projects.spring.io/spring-integration</url>
   <organization>
     <name>SpringIO</name>
     <url>https://spring.io</url>
@@ -14,7 +14,7 @@
   <licenses>
     <license>
       <name>The Apache Software License, Version 2.0</name>
-      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
       <distribution>repo</distribution>
     </license>
   </licenses>

--- a/basic/xml/pom.xml
+++ b/basic/xml/pom.xml
@@ -6,7 +6,7 @@
   <version>5.1.1.BUILD-SNAPSHOT</version>
   <name>XML Sample</name>
   <description>XML Sample</description>
-  <url>http://projects.spring.io/spring-integration</url>
+  <url>https://projects.spring.io/spring-integration</url>
   <organization>
     <name>SpringIO</name>
     <url>https://spring.io</url>
@@ -14,7 +14,7 @@
   <licenses>
     <license>
       <name>The Apache Software License, Version 2.0</name>
-      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
       <distribution>repo</distribution>
     </license>
   </licenses>

--- a/basic/xmpp/pom.xml
+++ b/basic/xmpp/pom.xml
@@ -6,7 +6,7 @@
   <version>5.1.1.BUILD-SNAPSHOT</version>
   <name>XMPP Basic Sample</name>
   <description>XMPP Basic Sample</description>
-  <url>http://projects.spring.io/spring-integration</url>
+  <url>https://projects.spring.io/spring-integration</url>
   <organization>
     <name>SpringIO</name>
     <url>https://spring.io</url>
@@ -14,7 +14,7 @@
   <licenses>
     <license>
       <name>The Apache Software License, Version 2.0</name>
-      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
       <distribution>repo</distribution>
     </license>
   </licenses>

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
 	repositories {
-		maven { url 'http://repo.spring.io/libs-snapshot' }
+		maven { url 'https://repo.spring.io/libs-snapshot' }
 	}
 	dependencies {
 		classpath 'io.spring.gradle:dependency-management-plugin:1.0.5.RELEASE'
@@ -18,7 +18,7 @@ apply plugin: 'base'
 apply plugin: 'idea'
 
 ext {
-	linkHomepage = 'http://projects.spring.io/spring-integration'
+	linkHomepage = 'https://projects.spring.io/spring-integration'
 	linkCi = 'https://build.spring.io/browse/INTSAMPLES'
 	linkIssue = 'https://jira.spring.io/browse/INTSAMPLES'
 	linkScmUrl = 'https://github.com/spring-projects/spring-integration-samples'
@@ -30,9 +30,9 @@ allprojects {
 	group = 'org.springframework.integration.samples'
 
 	repositories {
-		maven { url 'http://repo.spring.io/libs-snapshot' }
-		maven { url 'http://repo.spring.io/libs-milestone' }
-//			maven { url 'http://repo.spring.io/libs-staging-local' }
+		maven { url 'https://repo.spring.io/libs-snapshot' }
+		maven { url 'https://repo.spring.io/libs-milestone' }
+//			maven { url 'https://repo.spring.io/libs-staging-local' }
 	}
 
 }
@@ -59,7 +59,7 @@ subprojects { subproject ->
 					licenses {
 						license {
 							name 'The Apache Software License, Version 2.0'
-							url 'http://www.apache.org/licenses/LICENSE-2.0.txt'
+							url 'https://www.apache.org/licenses/LICENSE-2.0.txt'
 							distribution 'repo'
 						}
 					}

--- a/dsl/cafe-dsl/pom.xml
+++ b/dsl/cafe-dsl/pom.xml
@@ -11,7 +11,7 @@
   <version>5.1.1.BUILD-SNAPSHOT</version>
   <name>Java DSL Cafe Sample</name>
   <description>Java DSL Cafe Sample</description>
-  <url>http://projects.spring.io/spring-integration</url>
+  <url>https://projects.spring.io/spring-integration</url>
   <organization>
     <name>SpringIO</name>
     <url>https://spring.io</url>
@@ -19,7 +19,7 @@
   <licenses>
     <license>
       <name>The Apache Software License, Version 2.0</name>
-      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
       <distribution>repo</distribution>
     </license>
   </licenses>

--- a/dsl/kafka-dsl/pom.xml
+++ b/dsl/kafka-dsl/pom.xml
@@ -11,7 +11,7 @@
   <version>5.1.1.BUILD-SNAPSHOT</version>
   <name>Java DSL Kafka Sample</name>
   <description>Java DSL Kafka Sample</description>
-  <url>http://projects.spring.io/spring-integration</url>
+  <url>https://projects.spring.io/spring-integration</url>
   <organization>
     <name>SpringIO</name>
     <url>https://spring.io</url>
@@ -19,7 +19,7 @@
   <licenses>
     <license>
       <name>The Apache Software License, Version 2.0</name>
-      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
       <distribution>repo</distribution>
     </license>
   </licenses>

--- a/dsl/pom.xml
+++ b/dsl/pom.xml
@@ -4,7 +4,7 @@
   <groupId>org.springframework.integration.samples</groupId>
   <artifactId>dsl</artifactId>
   <version>5.1.1.BUILD-SNAPSHOT</version>
-  <url>http://projects.spring.io/spring-integration</url>
+  <url>https://projects.spring.io/spring-integration</url>
   <organization>
     <name>SpringIO</name>
     <url>https://spring.io</url>
@@ -12,7 +12,7 @@
   <licenses>
     <license>
       <name>The Apache Software License, Version 2.0</name>
-      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
       <distribution>repo</distribution>
     </license>
   </licenses>

--- a/dsl/si4demo/pom.xml
+++ b/dsl/si4demo/pom.xml
@@ -11,7 +11,7 @@
   <version>5.1.1.BUILD-SNAPSHOT</version>
   <name>Java Configuration/DSL Sample</name>
   <description>Java Configuration/DSL Sample</description>
-  <url>http://projects.spring.io/spring-integration</url>
+  <url>https://projects.spring.io/spring-integration</url>
   <organization>
     <name>SpringIO</name>
     <url>https://spring.io</url>
@@ -19,7 +19,7 @@
   <licenses>
     <license>
       <name>The Apache Software License, Version 2.0</name>
-      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
       <distribution>repo</distribution>
     </license>
   </licenses>

--- a/intermediate/async-gateway/pom.xml
+++ b/intermediate/async-gateway/pom.xml
@@ -6,7 +6,7 @@
   <version>5.1.1.BUILD-SNAPSHOT</version>
   <name>Async Gateway Sample</name>
   <description>Async Gateway Sample</description>
-  <url>http://projects.spring.io/spring-integration</url>
+  <url>https://projects.spring.io/spring-integration</url>
   <organization>
     <name>SpringIO</name>
     <url>https://spring.io</url>
@@ -14,7 +14,7 @@
   <licenses>
     <license>
       <name>The Apache Software License, Version 2.0</name>
-      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
       <distribution>repo</distribution>
     </license>
   </licenses>

--- a/intermediate/dynamic-poller/pom.xml
+++ b/intermediate/dynamic-poller/pom.xml
@@ -6,7 +6,7 @@
   <version>5.1.1.BUILD-SNAPSHOT</version>
   <name>Dynamic Poller Sample</name>
   <description>Dynamic Poller Sample</description>
-  <url>http://projects.spring.io/spring-integration</url>
+  <url>https://projects.spring.io/spring-integration</url>
   <organization>
     <name>SpringIO</name>
     <url>https://spring.io</url>
@@ -14,7 +14,7 @@
   <licenses>
     <license>
       <name>The Apache Software License, Version 2.0</name>
-      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
       <distribution>repo</distribution>
     </license>
   </licenses>

--- a/intermediate/errorhandling/pom.xml
+++ b/intermediate/errorhandling/pom.xml
@@ -6,7 +6,7 @@
   <version>5.1.1.BUILD-SNAPSHOT</version>
   <name>Error Handling Sample</name>
   <description>Error Handling Sample</description>
-  <url>http://projects.spring.io/spring-integration</url>
+  <url>https://projects.spring.io/spring-integration</url>
   <organization>
     <name>SpringIO</name>
     <url>https://spring.io</url>
@@ -14,7 +14,7 @@
   <licenses>
     <license>
       <name>The Apache Software License, Version 2.0</name>
-      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
       <distribution>repo</distribution>
     </license>
   </licenses>

--- a/intermediate/file-processing/pom.xml
+++ b/intermediate/file-processing/pom.xml
@@ -6,7 +6,7 @@
   <version>5.1.1.BUILD-SNAPSHOT</version>
   <name>File Processing Sample</name>
   <description>File Processing Sample</description>
-  <url>http://projects.spring.io/spring-integration</url>
+  <url>https://projects.spring.io/spring-integration</url>
   <organization>
     <name>SpringIO</name>
     <url>https://spring.io</url>
@@ -14,7 +14,7 @@
   <licenses>
     <license>
       <name>The Apache Software License, Version 2.0</name>
-      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
       <distribution>repo</distribution>
     </license>
   </licenses>

--- a/intermediate/mail-attachments/pom.xml
+++ b/intermediate/mail-attachments/pom.xml
@@ -6,7 +6,7 @@
   <version>5.1.1.BUILD-SNAPSHOT</version>
   <name>Mail Attachment Sample</name>
   <description>Mail Attachment Sample</description>
-  <url>http://projects.spring.io/spring-integration</url>
+  <url>https://projects.spring.io/spring-integration</url>
   <organization>
     <name>SpringIO</name>
     <url>https://spring.io</url>
@@ -14,7 +14,7 @@
   <licenses>
     <license>
       <name>The Apache Software License, Version 2.0</name>
-      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
       <distribution>repo</distribution>
     </license>
   </licenses>

--- a/intermediate/monitoring/pom.xml
+++ b/intermediate/monitoring/pom.xml
@@ -6,7 +6,7 @@
   <version>5.1.1.BUILD-SNAPSHOT</version>
   <name>Monitoring Application</name>
   <description>Monitoring Application</description>
-  <url>http://projects.spring.io/spring-integration</url>
+  <url>https://projects.spring.io/spring-integration</url>
   <organization>
     <name>SpringIO</name>
     <url>https://spring.io</url>
@@ -14,7 +14,7 @@
   <licenses>
     <license>
       <name>The Apache Software License, Version 2.0</name>
-      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
       <distribution>repo</distribution>
     </license>
   </licenses>

--- a/intermediate/multipart-http/pom.xml
+++ b/intermediate/multipart-http/pom.xml
@@ -6,7 +6,7 @@
   <version>5.1.1.BUILD-SNAPSHOT</version>
   <name>HTTP Multipart Demo</name>
   <description>HTTP Multipart Demo</description>
-  <url>http://projects.spring.io/spring-integration</url>
+  <url>https://projects.spring.io/spring-integration</url>
   <organization>
     <name>SpringIO</name>
     <url>https://spring.io</url>
@@ -14,7 +14,7 @@
   <licenses>
     <license>
       <name>The Apache Software License, Version 2.0</name>
-      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
       <distribution>repo</distribution>
     </license>
   </licenses>

--- a/intermediate/pom.xml
+++ b/intermediate/pom.xml
@@ -5,7 +5,7 @@
   <groupId>org.springframework.integration.samples</groupId>
   <artifactId>intermediate</artifactId>
   <version>5.1.1.BUILD-SNAPSHOT</version>
-  <url>http://projects.spring.io/spring-integration</url>
+  <url>https://projects.spring.io/spring-integration</url>
   <organization>
     <name>SpringIO</name>
     <url>https://spring.io</url>
@@ -13,7 +13,7 @@
   <licenses>
     <license>
       <name>The Apache Software License, Version 2.0</name>
-      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
       <distribution>repo</distribution>
     </license>
   </licenses>

--- a/intermediate/rest-http/pom.xml
+++ b/intermediate/rest-http/pom.xml
@@ -6,7 +6,7 @@
   <version>5.1.1.BUILD-SNAPSHOT</version>
   <name>Spring Integration Rest HTTP Path Usage Demo</name>
   <description>Spring Integration Rest HTTP Path Usage Demo</description>
-  <url>http://projects.spring.io/spring-integration</url>
+  <url>https://projects.spring.io/spring-integration</url>
   <organization>
     <name>SpringIO</name>
     <url>https://spring.io</url>
@@ -14,7 +14,7 @@
   <licenses>
     <license>
       <name>The Apache Software License, Version 2.0</name>
-      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
       <distribution>repo</distribution>
     </license>
   </licenses>

--- a/intermediate/retry-and-more/pom.xml
+++ b/intermediate/retry-and-more/pom.xml
@@ -6,7 +6,7 @@
   <version>5.1.1.BUILD-SNAPSHOT</version>
   <name>Retry and More Sample</name>
   <description>Retry and More Sample</description>
-  <url>http://projects.spring.io/spring-integration</url>
+  <url>https://projects.spring.io/spring-integration</url>
   <organization>
     <name>SpringIO</name>
     <url>https://spring.io</url>
@@ -14,7 +14,7 @@
   <licenses>
     <license>
       <name>The Apache Software License, Version 2.0</name>
-      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
       <distribution>repo</distribution>
     </license>
   </licenses>

--- a/intermediate/splitter-aggregator-reaper/pom.xml
+++ b/intermediate/splitter-aggregator-reaper/pom.xml
@@ -6,7 +6,7 @@
   <version>5.1.1.BUILD-SNAPSHOT</version>
   <name>Splitter-Aggregator-Reaper Sample</name>
   <description>Splitter-Aggregator-Reaper Sample</description>
-  <url>http://projects.spring.io/spring-integration</url>
+  <url>https://projects.spring.io/spring-integration</url>
   <organization>
     <name>SpringIO</name>
     <url>https://spring.io</url>
@@ -14,7 +14,7 @@
   <licenses>
     <license>
       <name>The Apache Software License, Version 2.0</name>
-      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
       <distribution>repo</distribution>
     </license>
   </licenses>

--- a/intermediate/stored-procedures-derby/pom.xml
+++ b/intermediate/stored-procedures-derby/pom.xml
@@ -6,7 +6,7 @@
   <version>5.1.1.BUILD-SNAPSHOT</version>
   <name>Derby Stored Procedures Sample</name>
   <description>Derby Stored Procedures Sample</description>
-  <url>http://projects.spring.io/spring-integration</url>
+  <url>https://projects.spring.io/spring-integration</url>
   <organization>
     <name>SpringIO</name>
     <url>https://spring.io</url>
@@ -14,7 +14,7 @@
   <licenses>
     <license>
       <name>The Apache Software License, Version 2.0</name>
-      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
       <distribution>repo</distribution>
     </license>
   </licenses>

--- a/intermediate/stored-procedures-ms/pom.xml
+++ b/intermediate/stored-procedures-ms/pom.xml
@@ -6,7 +6,7 @@
   <version>5.1.1.BUILD-SNAPSHOT</version>
   <name>MS SQLServer Stored Procedures Sample</name>
   <description>MS SQLServer Stored Procedures Sample</description>
-  <url>http://projects.spring.io/spring-integration</url>
+  <url>https://projects.spring.io/spring-integration</url>
   <organization>
     <name>SpringIO</name>
     <url>https://spring.io</url>
@@ -14,7 +14,7 @@
   <licenses>
     <license>
       <name>The Apache Software License, Version 2.0</name>
-      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
       <distribution>repo</distribution>
     </license>
   </licenses>

--- a/intermediate/stored-procedures-oracle/pom.xml
+++ b/intermediate/stored-procedures-oracle/pom.xml
@@ -6,7 +6,7 @@
   <version>5.1.1.BUILD-SNAPSHOT</version>
   <name>Oracle Stored Procedures Sample</name>
   <description>Oracle Stored Procedures Sample</description>
-  <url>http://projects.spring.io/spring-integration</url>
+  <url>https://projects.spring.io/spring-integration</url>
   <organization>
     <name>SpringIO</name>
     <url>https://spring.io</url>
@@ -14,7 +14,7 @@
   <licenses>
     <license>
       <name>The Apache Software License, Version 2.0</name>
-      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
       <distribution>repo</distribution>
     </license>
   </licenses>

--- a/intermediate/stored-procedures-postgresql/pom.xml
+++ b/intermediate/stored-procedures-postgresql/pom.xml
@@ -6,7 +6,7 @@
   <version>5.1.1.BUILD-SNAPSHOT</version>
   <name>PostgreSQL Stored Procedures Sample</name>
   <description>PostgreSQL Stored Procedures Sample</description>
-  <url>http://projects.spring.io/spring-integration</url>
+  <url>https://projects.spring.io/spring-integration</url>
   <organization>
     <name>SpringIO</name>
     <url>https://spring.io</url>
@@ -14,7 +14,7 @@
   <licenses>
     <license>
       <name>The Apache Software License, Version 2.0</name>
-      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
       <distribution>repo</distribution>
     </license>
   </licenses>

--- a/intermediate/tcp-client-server-multiplex/pom.xml
+++ b/intermediate/tcp-client-server-multiplex/pom.xml
@@ -6,7 +6,7 @@
   <version>5.1.1.BUILD-SNAPSHOT</version>
   <name>TCP Client Server Multiplexing Sample</name>
   <description>TCP Client Server Multiplexing Sample</description>
-  <url>http://projects.spring.io/spring-integration</url>
+  <url>https://projects.spring.io/spring-integration</url>
   <organization>
     <name>SpringIO</name>
     <url>https://spring.io</url>
@@ -14,7 +14,7 @@
   <licenses>
     <license>
       <name>The Apache Software License, Version 2.0</name>
-      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
       <distribution>repo</distribution>
     </license>
   </licenses>

--- a/intermediate/travel/pom.xml
+++ b/intermediate/travel/pom.xml
@@ -6,7 +6,7 @@
   <version>5.1.1.BUILD-SNAPSHOT</version>
   <name>Travel Services Sample</name>
   <description>Travel Services Sample</description>
-  <url>http://projects.spring.io/spring-integration</url>
+  <url>https://projects.spring.io/spring-integration</url>
   <organization>
     <name>SpringIO</name>
     <url>https://spring.io</url>
@@ -14,7 +14,7 @@
   <licenses>
     <license>
       <name>The Apache Software License, Version 2.0</name>
-      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
       <distribution>repo</distribution>
     </license>
   </licenses>

--- a/intermediate/tx-synch/pom.xml
+++ b/intermediate/tx-synch/pom.xml
@@ -6,7 +6,7 @@
   <version>5.1.1.BUILD-SNAPSHOT</version>
   <name>Transaction Synchronization Sample</name>
   <description>Transaction Synchronization Sample</description>
-  <url>http://projects.spring.io/spring-integration</url>
+  <url>https://projects.spring.io/spring-integration</url>
   <organization>
     <name>SpringIO</name>
     <url>https://spring.io</url>
@@ -14,7 +14,7 @@
   <licenses>
     <license>
       <name>The Apache Software License, Version 2.0</name>
-      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
       <distribution>repo</distribution>
     </license>
   </licenses>


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were fixed successfully.

* http://www.apache.org/licenses/LICENSE-2.0.txt migrated to:  
  https://www.apache.org/licenses/LICENSE-2.0.txt ([https](https://www.apache.org/licenses/LICENSE-2.0.txt) result 200).
* http://projects.spring.io/spring-integration migrated to:  
  https://projects.spring.io/spring-integration ([https](https://projects.spring.io/spring-integration) result 301).
* http://repo.spring.io/libs-milestone migrated to:  
  https://repo.spring.io/libs-milestone ([https](https://repo.spring.io/libs-milestone) result 302).
* http://repo.spring.io/libs-snapshot migrated to:  
  https://repo.spring.io/libs-snapshot ([https](https://repo.spring.io/libs-snapshot) result 302).
* http://repo.spring.io/libs-staging-local migrated to:  
  https://repo.spring.io/libs-staging-local ([https](https://repo.spring.io/libs-staging-local) result 302).

# Ignored
These URLs were intentionally ignored.

* http://maven.apache.org/POM/4.0.0
* http://maven.apache.org/xsd/maven-4.0.0.xsd
* http://www.w3.org/2001/XMLSchema-instance