### PR TITLE
URL Cleanup

### DIFF
--- a/advanced/advanced-testing-examples/src/test/java/org/springframework/integration/samples/advance/testing/jms/JmsMockTests.java
+++ b/advanced/advanced-testing-examples/src/test/java/org/springframework/integration/samples/advance/testing/jms/JmsMockTests.java
@@ -4,7 +4,7 @@
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/advanced/dynamic-ftp/src/main/java/org/springframework/integration/samples/ftp/DynamicFtpChannelResolver.java
+++ b/advanced/dynamic-ftp/src/main/java/org/springframework/integration/samples/ftp/DynamicFtpChannelResolver.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/advanced/dynamic-ftp/src/test/java/org/springframework/integration/samples/ftp/DynamicFtpChannelResolverTests.java
+++ b/advanced/dynamic-ftp/src/test/java/org/springframework/integration/samples/ftp/DynamicFtpChannelResolverTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/advanced/dynamic-ftp/src/test/java/org/springframework/integration/samples/ftp/FtpOutboundChannelAdapterSample.java
+++ b/advanced/dynamic-ftp/src/test/java/org/springframework/integration/samples/ftp/FtpOutboundChannelAdapterSample.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/applications/cafe-scripted/src/main/java/org/springframework/integration/samples/cafe/Customer.java
+++ b/applications/cafe-scripted/src/main/java/org/springframework/integration/samples/cafe/Customer.java
@@ -4,7 +4,7 @@
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  * 
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/applications/cafe-scripted/src/main/java/org/springframework/integration/samples/cafe/Delivery.java
+++ b/applications/cafe-scripted/src/main/java/org/springframework/integration/samples/cafe/Delivery.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/applications/cafe-scripted/src/main/java/org/springframework/integration/samples/cafe/Drink.java
+++ b/applications/cafe-scripted/src/main/java/org/springframework/integration/samples/cafe/Drink.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/applications/cafe-scripted/src/main/java/org/springframework/integration/samples/cafe/DrinkType.java
+++ b/applications/cafe-scripted/src/main/java/org/springframework/integration/samples/cafe/DrinkType.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/applications/cafe-scripted/src/main/java/org/springframework/integration/samples/cafe/Order.java
+++ b/applications/cafe-scripted/src/main/java/org/springframework/integration/samples/cafe/Order.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/applications/cafe-scripted/src/main/java/org/springframework/integration/samples/cafe/OrderItem.java
+++ b/applications/cafe-scripted/src/main/java/org/springframework/integration/samples/cafe/OrderItem.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/applications/cafe-scripted/src/main/java/org/springframework/integration/samples/cafe/Waiter.java
+++ b/applications/cafe-scripted/src/main/java/org/springframework/integration/samples/cafe/Waiter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/applications/cafe-scripted/src/main/java/org/springframework/integration/samples/cafe/WaiterMonitor.java
+++ b/applications/cafe-scripted/src/main/java/org/springframework/integration/samples/cafe/WaiterMonitor.java
@@ -4,7 +4,7 @@
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  * 
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/applications/cafe-scripted/src/main/java/org/springframework/integration/samples/cafe/demo/CafeDemoApp.java
+++ b/applications/cafe-scripted/src/main/java/org/springframework/integration/samples/cafe/demo/CafeDemoApp.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/applications/cafe-scripted/src/main/java/org/springframework/integration/samples/cafe/demo/ControlBusMain.java
+++ b/applications/cafe-scripted/src/main/java/org/springframework/integration/samples/cafe/demo/ControlBusMain.java
@@ -4,7 +4,7 @@
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  * 
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/applications/cafe-scripted/src/test/java/org/springframework/integration/samples/cafe/ScriptTests.java
+++ b/applications/cafe-scripted/src/test/java/org/springframework/integration/samples/cafe/ScriptTests.java
@@ -4,7 +4,7 @@
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/applications/cafe/cafe-amqp/src/main/java/org/springframework/integration/samples/cafe/xml/CafeDemoAppAmqp.java
+++ b/applications/cafe/cafe-amqp/src/main/java/org/springframework/integration/samples/cafe/xml/CafeDemoAppAmqp.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/applications/cafe/cafe-amqp/src/main/java/org/springframework/integration/samples/cafe/xml/CafeDemoAppBaristaColdAmqp.java
+++ b/applications/cafe/cafe-amqp/src/main/java/org/springframework/integration/samples/cafe/xml/CafeDemoAppBaristaColdAmqp.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/applications/cafe/cafe-amqp/src/main/java/org/springframework/integration/samples/cafe/xml/CafeDemoAppBaristaHotAmqp.java
+++ b/applications/cafe/cafe-amqp/src/main/java/org/springframework/integration/samples/cafe/xml/CafeDemoAppBaristaHotAmqp.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/applications/cafe/cafe-amqp/src/main/java/org/springframework/integration/samples/cafe/xml/CafeDemoAppOperationsAmqp.java
+++ b/applications/cafe/cafe-amqp/src/main/java/org/springframework/integration/samples/cafe/xml/CafeDemoAppOperationsAmqp.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/applications/cafe/cafe-jms/src/main/java/org/springframework/integration/samples/cafe/xml/CafeDemoActiveMQBackedChannels.java
+++ b/applications/cafe/cafe-jms/src/main/java/org/springframework/integration/samples/cafe/xml/CafeDemoActiveMQBackedChannels.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/applications/cafe/cafe-jms/src/main/java/org/springframework/integration/samples/cafe/xml/CafeDemoAppActiveMQ.java
+++ b/applications/cafe/cafe-jms/src/main/java/org/springframework/integration/samples/cafe/xml/CafeDemoAppActiveMQ.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/applications/cafe/cafe-jms/src/main/java/org/springframework/integration/samples/cafe/xml/CafeDemoAppBaristaColdActiveMQ.java
+++ b/applications/cafe/cafe-jms/src/main/java/org/springframework/integration/samples/cafe/xml/CafeDemoAppBaristaColdActiveMQ.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/applications/cafe/cafe-jms/src/main/java/org/springframework/integration/samples/cafe/xml/CafeDemoAppBaristaHotActiveMQ.java
+++ b/applications/cafe/cafe-jms/src/main/java/org/springframework/integration/samples/cafe/xml/CafeDemoAppBaristaHotActiveMQ.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/applications/cafe/cafe-jms/src/main/java/org/springframework/integration/samples/cafe/xml/CafeDemoAppOperationsActiveMQ.java
+++ b/applications/cafe/cafe-jms/src/main/java/org/springframework/integration/samples/cafe/xml/CafeDemoAppOperationsActiveMQ.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/applications/cafe/cafe-si/src/main/java/org/springframework/integration/samples/cafe/Cafe.java
+++ b/applications/cafe/cafe-si/src/main/java/org/springframework/integration/samples/cafe/Cafe.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/applications/cafe/cafe-si/src/main/java/org/springframework/integration/samples/cafe/Delivery.java
+++ b/applications/cafe/cafe-si/src/main/java/org/springframework/integration/samples/cafe/Delivery.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/applications/cafe/cafe-si/src/main/java/org/springframework/integration/samples/cafe/Drink.java
+++ b/applications/cafe/cafe-si/src/main/java/org/springframework/integration/samples/cafe/Drink.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/applications/cafe/cafe-si/src/main/java/org/springframework/integration/samples/cafe/DrinkType.java
+++ b/applications/cafe/cafe-si/src/main/java/org/springframework/integration/samples/cafe/DrinkType.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/applications/cafe/cafe-si/src/main/java/org/springframework/integration/samples/cafe/Order.java
+++ b/applications/cafe/cafe-si/src/main/java/org/springframework/integration/samples/cafe/Order.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/applications/cafe/cafe-si/src/main/java/org/springframework/integration/samples/cafe/OrderItem.java
+++ b/applications/cafe/cafe-si/src/main/java/org/springframework/integration/samples/cafe/OrderItem.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/applications/cafe/cafe-si/src/main/java/org/springframework/integration/samples/cafe/annotation/Barista.java
+++ b/applications/cafe/cafe-si/src/main/java/org/springframework/integration/samples/cafe/annotation/Barista.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/applications/cafe/cafe-si/src/main/java/org/springframework/integration/samples/cafe/annotation/CafeDemoApp.java
+++ b/applications/cafe/cafe-si/src/main/java/org/springframework/integration/samples/cafe/annotation/CafeDemoApp.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/applications/cafe/cafe-si/src/main/java/org/springframework/integration/samples/cafe/annotation/DrinkRouter.java
+++ b/applications/cafe/cafe-si/src/main/java/org/springframework/integration/samples/cafe/annotation/DrinkRouter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/applications/cafe/cafe-si/src/main/java/org/springframework/integration/samples/cafe/annotation/OrderSplitter.java
+++ b/applications/cafe/cafe-si/src/main/java/org/springframework/integration/samples/cafe/annotation/OrderSplitter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/applications/cafe/cafe-si/src/main/java/org/springframework/integration/samples/cafe/annotation/Waiter.java
+++ b/applications/cafe/cafe-si/src/main/java/org/springframework/integration/samples/cafe/annotation/Waiter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/applications/cafe/cafe-si/src/main/java/org/springframework/integration/samples/cafe/xml/Barista.java
+++ b/applications/cafe/cafe-si/src/main/java/org/springframework/integration/samples/cafe/xml/Barista.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/applications/cafe/cafe-si/src/main/java/org/springframework/integration/samples/cafe/xml/CafeDemoApp.java
+++ b/applications/cafe/cafe-si/src/main/java/org/springframework/integration/samples/cafe/xml/CafeDemoApp.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/applications/cafe/cafe-si/src/main/java/org/springframework/integration/samples/cafe/xml/CafeDemoAppUtilities.java
+++ b/applications/cafe/cafe-si/src/main/java/org/springframework/integration/samples/cafe/xml/CafeDemoAppUtilities.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/applications/cafe/cafe-si/src/main/java/org/springframework/integration/samples/cafe/xml/Waiter.java
+++ b/applications/cafe/cafe-si/src/main/java/org/springframework/integration/samples/cafe/xml/Waiter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/applications/loan-broker/src/main/java/org/springframework/integration/samples/loanbroker/LoanBrokerGateway.java
+++ b/applications/loan-broker/src/main/java/org/springframework/integration/samples/loanbroker/LoanBrokerGateway.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/applications/loan-broker/src/main/java/org/springframework/integration/samples/loanbroker/LoanQuoteAggregator.java
+++ b/applications/loan-broker/src/main/java/org/springframework/integration/samples/loanbroker/LoanQuoteAggregator.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/applications/loan-broker/src/main/java/org/springframework/integration/samples/loanbroker/demo/LoanBrokerDemo.java
+++ b/applications/loan-broker/src/main/java/org/springframework/integration/samples/loanbroker/demo/LoanBrokerDemo.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/applications/loan-broker/src/main/java/org/springframework/integration/samples/loanbroker/demo/LoanBrokerSharkDetectorDemo.java
+++ b/applications/loan-broker/src/main/java/org/springframework/integration/samples/loanbroker/demo/LoanBrokerSharkDetectorDemo.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/applications/loan-broker/src/main/java/org/springframework/integration/samples/loanbroker/domain/Address.java
+++ b/applications/loan-broker/src/main/java/org/springframework/integration/samples/loanbroker/domain/Address.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/applications/loan-broker/src/main/java/org/springframework/integration/samples/loanbroker/domain/CreditReport.java
+++ b/applications/loan-broker/src/main/java/org/springframework/integration/samples/loanbroker/domain/CreditReport.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/applications/loan-broker/src/main/java/org/springframework/integration/samples/loanbroker/domain/Customer.java
+++ b/applications/loan-broker/src/main/java/org/springframework/integration/samples/loanbroker/domain/Customer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/applications/loan-broker/src/main/java/org/springframework/integration/samples/loanbroker/domain/LoanQuote.java
+++ b/applications/loan-broker/src/main/java/org/springframework/integration/samples/loanbroker/domain/LoanQuote.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/applications/loan-broker/src/main/java/org/springframework/integration/samples/loanbroker/domain/LoanRequest.java
+++ b/applications/loan-broker/src/main/java/org/springframework/integration/samples/loanbroker/domain/LoanRequest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/applications/loan-broker/src/main/java/org/springframework/integration/samples/loanbroker/stubs/BankStub.java
+++ b/applications/loan-broker/src/main/java/org/springframework/integration/samples/loanbroker/stubs/BankStub.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/applications/loan-broker/src/main/java/org/springframework/integration/samples/loanbroker/stubs/CreditBureauStub.java
+++ b/applications/loan-broker/src/main/java/org/springframework/integration/samples/loanbroker/stubs/CreditBureauStub.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/applications/loanshark/src/main/java/org/springframework/integration/samples/loanbroker/loanshark/biz/Accumulator.java
+++ b/applications/loanshark/src/main/java/org/springframework/integration/samples/loanbroker/loanshark/biz/Accumulator.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/applications/loanshark/src/main/java/org/springframework/integration/samples/loanbroker/loanshark/biz/SharkQuote.java
+++ b/applications/loanshark/src/main/java/org/springframework/integration/samples/loanbroker/loanshark/biz/SharkQuote.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/applications/loanshark/src/main/java/org/springframework/integration/samples/loanbroker/loanshark/biz/SharkTransformer.java
+++ b/applications/loanshark/src/main/java/org/springframework/integration/samples/loanbroker/loanshark/biz/SharkTransformer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/applications/loanshark/src/main/java/org/springframework/integration/samples/loanbroker/loanshark/domain/LoanShark.java
+++ b/applications/loanshark/src/main/java/org/springframework/integration/samples/loanbroker/loanshark/domain/LoanShark.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/applications/loanshark/src/main/java/org/springframework/integration/samples/loanbroker/loanshark/web/SharkController.java
+++ b/applications/loanshark/src/main/java/org/springframework/integration/samples/loanbroker/loanshark/web/SharkController.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/applications/loanshark/src/test/java/org/springframework/integration/samples/loanbroker/loanshark/biz/AccumulatorTests.java
+++ b/applications/loanshark/src/test/java/org/springframework/integration/samples/loanbroker/loanshark/biz/AccumulatorTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/applications/stomp-chat/src/main/java/org/springframework/integration/samples/chat/stomp/server/Application.java
+++ b/applications/stomp-chat/src/main/java/org/springframework/integration/samples/chat/stomp/server/Application.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/applications/stomp-chat/src/test/java/org/springframework/integration/samples/chat/stomp/server/ApplicationTests.java
+++ b/applications/stomp-chat/src/test/java/org/springframework/integration/samples/chat/stomp/server/ApplicationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/basic/amqp/src/main/java/org/springframework/integration/samples/amqp/SamplePubConfirmsReturns.java
+++ b/basic/amqp/src/main/java/org/springframework/integration/samples/amqp/SamplePubConfirmsReturns.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/basic/amqp/src/main/java/org/springframework/integration/samples/amqp/SampleSimple.java
+++ b/basic/amqp/src/main/java/org/springframework/integration/samples/amqp/SampleSimple.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/basic/barrier/src/main/java/org/springframework/integration/samples/barrier/AckAggregator.java
+++ b/basic/barrier/src/main/java/org/springframework/integration/samples/barrier/AckAggregator.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/basic/barrier/src/main/java/org/springframework/integration/samples/barrier/Application.java
+++ b/basic/barrier/src/main/java/org/springframework/integration/samples/barrier/Application.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/basic/barrier/src/main/java/org/springframework/integration/samples/barrier/RequestGateway.java
+++ b/basic/barrier/src/main/java/org/springframework/integration/samples/barrier/RequestGateway.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/basic/barrier/src/main/java/org/springframework/integration/samples/barrier2/Aggregator.java
+++ b/basic/barrier/src/main/java/org/springframework/integration/samples/barrier2/Aggregator.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/basic/barrier/src/main/java/org/springframework/integration/samples/barrier2/ErrorHandlingApplication.java
+++ b/basic/barrier/src/main/java/org/springframework/integration/samples/barrier2/ErrorHandlingApplication.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/basic/barrier/src/main/java/org/springframework/integration/samples/barrier2/Gateway.java
+++ b/basic/barrier/src/main/java/org/springframework/integration/samples/barrier2/Gateway.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/basic/barrier/src/test/java/org/springframework/integration/samples/barrier/ApplicationTests.java
+++ b/basic/barrier/src/test/java/org/springframework/integration/samples/barrier/ApplicationTests.java
@@ -6,7 +6,7 @@ package org.springframework.integration.samples.barrier;
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/basic/control-bus/src/test/java/org/springframework/integration/samples/controlbus/ControlBusDemoTest.java
+++ b/basic/control-bus/src/test/java/org/springframework/integration/samples/controlbus/ControlBusDemoTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/basic/enricher/src/main/java/org/springframework/integration/samples/enricher/Main.java
+++ b/basic/enricher/src/main/java/org/springframework/integration/samples/enricher/Main.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/basic/enricher/src/main/java/org/springframework/integration/samples/enricher/domain/User.java
+++ b/basic/enricher/src/main/java/org/springframework/integration/samples/enricher/domain/User.java
@@ -4,7 +4,7 @@
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/basic/enricher/src/main/java/org/springframework/integration/samples/enricher/service/UserService.java
+++ b/basic/enricher/src/main/java/org/springframework/integration/samples/enricher/service/UserService.java
@@ -5,7 +5,7 @@
  *     you may not use this file except in compliance with the License.
  *     You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  *     Unless required by applicable law or agreed to in writing, software
  *     distributed under the License is distributed on an "AS IS" BASIS,

--- a/basic/enricher/src/main/java/org/springframework/integration/samples/enricher/service/impl/SystemService.java
+++ b/basic/enricher/src/main/java/org/springframework/integration/samples/enricher/service/impl/SystemService.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/basic/enricher/src/test/java/org/springframework/integration/samples/enricher/service/UserServiceTest.java
+++ b/basic/enricher/src/test/java/org/springframework/integration/samples/enricher/service/UserServiceTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/basic/feed/src/test/java/org/springframework/integration/samples/feed/FeedInboundChannelAdapterSample.java
+++ b/basic/feed/src/test/java/org/springframework/integration/samples/feed/FeedInboundChannelAdapterSample.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/basic/file/src/main/java/org/springframework/integration/samples/filecopy/FileCopyDemoCommon.java
+++ b/basic/file/src/main/java/org/springframework/integration/samples/filecopy/FileCopyDemoCommon.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/basic/file/src/main/java/org/springframework/integration/samples/filecopy/Handler.java
+++ b/basic/file/src/main/java/org/springframework/integration/samples/filecopy/Handler.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/basic/file/src/test/java/org/springframework/integration/samples/filecopy/BinaryFileCopyTest.java
+++ b/basic/file/src/test/java/org/springframework/integration/samples/filecopy/BinaryFileCopyTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/basic/file/src/test/java/org/springframework/integration/samples/filecopy/FileBasedFileCopyTest.java
+++ b/basic/file/src/test/java/org/springframework/integration/samples/filecopy/FileBasedFileCopyTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/basic/file/src/test/java/org/springframework/integration/samples/filecopy/TextFileCopyTest.java
+++ b/basic/file/src/test/java/org/springframework/integration/samples/filecopy/TextFileCopyTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/basic/ftp/src/test/java/org/springframework/integration/samples/ftp/FtpInboundChannelAdapterSample.java
+++ b/basic/ftp/src/test/java/org/springframework/integration/samples/ftp/FtpInboundChannelAdapterSample.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/basic/ftp/src/test/java/org/springframework/integration/samples/ftp/FtpOutboundChannelAdapterSample.java
+++ b/basic/ftp/src/test/java/org/springframework/integration/samples/ftp/FtpOutboundChannelAdapterSample.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/basic/ftp/src/test/java/org/springframework/integration/samples/ftp/FtpOutboundGatewaySample.java
+++ b/basic/ftp/src/test/java/org/springframework/integration/samples/ftp/FtpOutboundGatewaySample.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/basic/ftp/src/test/java/org/springframework/integration/samples/ftp/TestSuite.java
+++ b/basic/ftp/src/test/java/org/springframework/integration/samples/ftp/TestSuite.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/basic/ftp/src/test/java/org/springframework/integration/samples/ftp/ToFtpFlowGateway.java
+++ b/basic/ftp/src/test/java/org/springframework/integration/samples/ftp/ToFtpFlowGateway.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/basic/ftp/src/test/java/org/springframework/integration/samples/ftp/support/TestUserManager.java
+++ b/basic/ftp/src/test/java/org/springframework/integration/samples/ftp/support/TestUserManager.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/basic/helloworld/src/main/java/org/springframework/integration/samples/helloworld/HelloService.java
+++ b/basic/helloworld/src/main/java/org/springframework/integration/samples/helloworld/HelloService.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/basic/helloworld/src/main/java/org/springframework/integration/samples/helloworld/HelloWorldApp.java
+++ b/basic/helloworld/src/main/java/org/springframework/integration/samples/helloworld/HelloWorldApp.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/basic/helloworld/src/main/java/org/springframework/integration/samples/helloworld/PollerApp.java
+++ b/basic/helloworld/src/main/java/org/springframework/integration/samples/helloworld/PollerApp.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/basic/http/src/main/java/org/springframework/integration/samples/http/HttpClientDemo.java
+++ b/basic/http/src/main/java/org/springframework/integration/samples/http/HttpClientDemo.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/basic/http/src/main/java/org/springframework/integration/samples/http/RequestGateway.java
+++ b/basic/http/src/main/java/org/springframework/integration/samples/http/RequestGateway.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/basic/jdbc/src/main/java/org/springframework/integration/samples/jdbc/Main.java
+++ b/basic/jdbc/src/main/java/org/springframework/integration/samples/jdbc/Main.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/basic/jdbc/src/main/java/org/springframework/integration/samples/jdbc/domain/Gender.java
+++ b/basic/jdbc/src/main/java/org/springframework/integration/samples/jdbc/domain/Gender.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/basic/jdbc/src/main/java/org/springframework/integration/samples/jdbc/domain/Person.java
+++ b/basic/jdbc/src/main/java/org/springframework/integration/samples/jdbc/domain/Person.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/basic/jdbc/src/main/java/org/springframework/integration/samples/jdbc/domain/PersonMapper.java
+++ b/basic/jdbc/src/main/java/org/springframework/integration/samples/jdbc/domain/PersonMapper.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/basic/jdbc/src/main/java/org/springframework/integration/samples/jdbc/domain/User.java
+++ b/basic/jdbc/src/main/java/org/springframework/integration/samples/jdbc/domain/User.java
@@ -4,7 +4,7 @@
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/basic/jdbc/src/main/java/org/springframework/integration/samples/jdbc/domain/UserMapper.java
+++ b/basic/jdbc/src/main/java/org/springframework/integration/samples/jdbc/domain/UserMapper.java
@@ -4,7 +4,7 @@
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/basic/jdbc/src/main/java/org/springframework/integration/samples/jdbc/service/PersonService.java
+++ b/basic/jdbc/src/main/java/org/springframework/integration/samples/jdbc/service/PersonService.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/basic/jdbc/src/test/java/org/springframework/integration/samples/jdbc/OutboundGatewayTest.java
+++ b/basic/jdbc/src/test/java/org/springframework/integration/samples/jdbc/OutboundGatewayTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/basic/jms/src/main/java/org/springframework/integration/samples/jms/ActiveMqTestUtils.java
+++ b/basic/jms/src/main/java/org/springframework/integration/samples/jms/ActiveMqTestUtils.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/basic/jms/src/main/java/org/springframework/integration/samples/jms/DemoBean.java
+++ b/basic/jms/src/main/java/org/springframework/integration/samples/jms/DemoBean.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/basic/jms/src/main/java/org/springframework/integration/samples/jms/Main.java
+++ b/basic/jms/src/main/java/org/springframework/integration/samples/jms/Main.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/basic/jms/src/test/java/org/springframework/integration/samples/jms/AggregatorDemoTest.java
+++ b/basic/jms/src/test/java/org/springframework/integration/samples/jms/AggregatorDemoTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/basic/jms/src/test/java/org/springframework/integration/samples/jms/ChannelAdapterDemoTest.java
+++ b/basic/jms/src/test/java/org/springframework/integration/samples/jms/ChannelAdapterDemoTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/basic/jms/src/test/java/org/springframework/integration/samples/jms/GatewayDemoTest.java
+++ b/basic/jms/src/test/java/org/springframework/integration/samples/jms/GatewayDemoTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/basic/jmx/src/main/java/org/springframework/integration/samples/jmx/StopWatch.java
+++ b/basic/jmx/src/main/java/org/springframework/integration/samples/jmx/StopWatch.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/basic/jmx/src/test/java/org/springframework/integration/samples/jmx/JmxAdapterDemoTest.java
+++ b/basic/jmx/src/test/java/org/springframework/integration/samples/jmx/JmxAdapterDemoTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/basic/jpa/src/main/java/org/springframework/integration/samples/jpa/Main.java
+++ b/basic/jpa/src/main/java/org/springframework/integration/samples/jpa/Main.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/basic/jpa/src/main/java/org/springframework/integration/samples/jpa/domain/Person.java
+++ b/basic/jpa/src/main/java/org/springframework/integration/samples/jpa/domain/Person.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/basic/jpa/src/main/java/org/springframework/integration/samples/jpa/service/PersonService.java
+++ b/basic/jpa/src/main/java/org/springframework/integration/samples/jpa/service/PersonService.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/basic/jpa/src/test/java/org/springframework/integration/samples/jpa/OutboundGatewayTest.java
+++ b/basic/jpa/src/test/java/org/springframework/integration/samples/jpa/OutboundGatewayTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/basic/kafka/src/main/java/org/springframework/integration/samples/kafka/Application.java
+++ b/basic/kafka/src/main/java/org/springframework/integration/samples/kafka/Application.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/basic/kafka/src/test/java/org/springframework/integration/samples/kafka/ApplicationTests.java
+++ b/basic/kafka/src/test/java/org/springframework/integration/samples/kafka/ApplicationTests.java
@@ -6,7 +6,7 @@ package org.springframework.integration.samples.kafka;
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/basic/kafka/src/test/java/org/springframework/integration/samples/kafka/KafkaRunning.java
+++ b/basic/kafka/src/test/java/org/springframework/integration/samples/kafka/KafkaRunning.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/basic/mail/src/main/java/org/springframework/integration/samples/mail/imapidle/GmailInboundImapIdleAdapterTestApp.java
+++ b/basic/mail/src/main/java/org/springframework/integration/samples/mail/imapidle/GmailInboundImapIdleAdapterTestApp.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/basic/mail/src/main/java/org/springframework/integration/samples/mail/imapidle/GmailInboundPop3AdapterTestApp.java
+++ b/basic/mail/src/main/java/org/springframework/integration/samples/mail/imapidle/GmailInboundPop3AdapterTestApp.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/basic/mongodb/src/main/java/org/springframework/integration/samples/mongodb/domain/Address.java
+++ b/basic/mongodb/src/main/java/org/springframework/integration/samples/mongodb/domain/Address.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/basic/mongodb/src/main/java/org/springframework/integration/samples/mongodb/domain/Person.java
+++ b/basic/mongodb/src/main/java/org/springframework/integration/samples/mongodb/domain/Person.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/basic/mongodb/src/main/java/org/springframework/integration/samples/mongodb/inbound/MongoDbInboundAdapterDemo.java
+++ b/basic/mongodb/src/main/java/org/springframework/integration/samples/mongodb/inbound/MongoDbInboundAdapterDemo.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/basic/mongodb/src/main/java/org/springframework/integration/samples/mongodb/outbound/MongoDbOutboundAdapterDemo.java
+++ b/basic/mongodb/src/main/java/org/springframework/integration/samples/mongodb/outbound/MongoDbOutboundAdapterDemo.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/basic/mongodb/src/main/java/org/springframework/integration/samples/mongodb/util/DemoUtils.java
+++ b/basic/mongodb/src/main/java/org/springframework/integration/samples/mongodb/util/DemoUtils.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/basic/mongodb/src/main/java/org/springframework/integration/samples/mongodb/util/StringConverter.java
+++ b/basic/mongodb/src/main/java/org/springframework/integration/samples/mongodb/util/StringConverter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/basic/oddeven/src/main/java/org/springframework/integration/samples/oddeven/Counter.java
+++ b/basic/oddeven/src/main/java/org/springframework/integration/samples/oddeven/Counter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/basic/oddeven/src/main/java/org/springframework/integration/samples/oddeven/CronOddEvenDemo.java
+++ b/basic/oddeven/src/main/java/org/springframework/integration/samples/oddeven/CronOddEvenDemo.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/basic/oddeven/src/main/java/org/springframework/integration/samples/oddeven/EvenLogger.java
+++ b/basic/oddeven/src/main/java/org/springframework/integration/samples/oddeven/EvenLogger.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/basic/oddeven/src/main/java/org/springframework/integration/samples/oddeven/IntervalOddEvenDemoTestApp.java
+++ b/basic/oddeven/src/main/java/org/springframework/integration/samples/oddeven/IntervalOddEvenDemoTestApp.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/basic/oddeven/src/main/java/org/springframework/integration/samples/oddeven/OddLogger.java
+++ b/basic/oddeven/src/main/java/org/springframework/integration/samples/oddeven/OddLogger.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/basic/quote/src/main/java/org/springframework/integration/samples/quote/Quote.java
+++ b/basic/quote/src/main/java/org/springframework/integration/samples/quote/Quote.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/basic/quote/src/main/java/org/springframework/integration/samples/quote/QuoteService.java
+++ b/basic/quote/src/main/java/org/springframework/integration/samples/quote/QuoteService.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/basic/quote/src/main/java/org/springframework/integration/samples/quote/TickerStream.java
+++ b/basic/quote/src/main/java/org/springframework/integration/samples/quote/TickerStream.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/basic/quote/src/test/java/org/springframework/integration/samples/quote/QuoteDemoTest.java
+++ b/basic/quote/src/test/java/org/springframework/integration/samples/quote/QuoteDemoTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/basic/sftp/src/test/java/org/springframework/integration/samples/sftp/EmbeddedSftpServer.java
+++ b/basic/sftp/src/test/java/org/springframework/integration/samples/sftp/EmbeddedSftpServer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/basic/sftp/src/test/java/org/springframework/integration/samples/sftp/SftpInboundReceiveSample.java
+++ b/basic/sftp/src/test/java/org/springframework/integration/samples/sftp/SftpInboundReceiveSample.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/basic/sftp/src/test/java/org/springframework/integration/samples/sftp/SftpOutboundGatewaySample.java
+++ b/basic/sftp/src/test/java/org/springframework/integration/samples/sftp/SftpOutboundGatewaySample.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/basic/sftp/src/test/java/org/springframework/integration/samples/sftp/SftpOutboundTransferSample.java
+++ b/basic/sftp/src/test/java/org/springframework/integration/samples/sftp/SftpOutboundTransferSample.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/basic/sftp/src/test/java/org/springframework/integration/samples/sftp/SftpTestUtils.java
+++ b/basic/sftp/src/test/java/org/springframework/integration/samples/sftp/SftpTestUtils.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/basic/sftp/src/test/java/org/springframework/integration/samples/sftp/ToSftpFlowGateway.java
+++ b/basic/sftp/src/test/java/org/springframework/integration/samples/sftp/ToSftpFlowGateway.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/basic/splunk/src/main/java/org/springframework/integration/samples/splunk/Application.java
+++ b/basic/splunk/src/main/java/org/springframework/integration/samples/splunk/Application.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/basic/splunk/src/main/java/org/springframework/integration/samples/splunk/event/OrderEvent.java
+++ b/basic/splunk/src/main/java/org/springframework/integration/samples/splunk/event/OrderEvent.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/basic/splunk/src/test/java/org/springframework/integration/samples/splunk/ApplicationTests.java
+++ b/basic/splunk/src/test/java/org/springframework/integration/samples/splunk/ApplicationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/basic/splunk/src/test/java/org/springframework/integration/samples/splunk/SplunkWatcher.java
+++ b/basic/splunk/src/test/java/org/springframework/integration/samples/splunk/SplunkWatcher.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/basic/tcp-amqp/src/main/java/org/springframework/integration/samples/tcpamqp/Main.java
+++ b/basic/tcp-amqp/src/main/java/org/springframework/integration/samples/tcpamqp/Main.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *	  http://www.apache.org/licenses/LICENSE-2.0
+ *	  https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/basic/tcp-client-server/src/main/java/org/springframework/integration/samples/tcpclientserver/ByteArrayToStringConverter.java
+++ b/basic/tcp-client-server/src/main/java/org/springframework/integration/samples/tcpclientserver/ByteArrayToStringConverter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/basic/tcp-client-server/src/main/java/org/springframework/integration/samples/tcpclientserver/CustomOrder.java
+++ b/basic/tcp-client-server/src/main/java/org/springframework/integration/samples/tcpclientserver/CustomOrder.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/basic/tcp-client-server/src/main/java/org/springframework/integration/samples/tcpclientserver/CustomSerializerDeserializer.java
+++ b/basic/tcp-client-server/src/main/java/org/springframework/integration/samples/tcpclientserver/CustomSerializerDeserializer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/basic/tcp-client-server/src/main/java/org/springframework/integration/samples/tcpclientserver/EchoService.java
+++ b/basic/tcp-client-server/src/main/java/org/springframework/integration/samples/tcpclientserver/EchoService.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/basic/tcp-client-server/src/main/java/org/springframework/integration/samples/tcpclientserver/Main.java
+++ b/basic/tcp-client-server/src/main/java/org/springframework/integration/samples/tcpclientserver/Main.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/basic/tcp-client-server/src/main/java/org/springframework/integration/samples/tcpclientserver/SimpleGateway.java
+++ b/basic/tcp-client-server/src/main/java/org/springframework/integration/samples/tcpclientserver/SimpleGateway.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/basic/tcp-client-server/src/test/java/org/springframework/integration/samples/tcpclientserver/TcpClientServerAnnotationDemoTest.java
+++ b/basic/tcp-client-server/src/test/java/org/springframework/integration/samples/tcpclientserver/TcpClientServerAnnotationDemoTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/basic/tcp-client-server/src/test/java/org/springframework/integration/samples/tcpclientserver/TcpClientServerDemoTest.java
+++ b/basic/tcp-client-server/src/test/java/org/springframework/integration/samples/tcpclientserver/TcpClientServerDemoTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/basic/tcp-client-server/src/test/java/org/springframework/integration/samples/tcpclientserver/TcpClientServerDemoWithConversionServiceTest.java
+++ b/basic/tcp-client-server/src/test/java/org/springframework/integration/samples/tcpclientserver/TcpClientServerDemoWithConversionServiceTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/basic/tcp-client-server/src/test/java/org/springframework/integration/samples/tcpclientserver/TcpServerConnectionDeserializeTest.java
+++ b/basic/tcp-client-server/src/test/java/org/springframework/integration/samples/tcpclientserver/TcpServerConnectionDeserializeTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/basic/tcp-client-server/src/test/java/org/springframework/integration/samples/tcpclientserver/TcpServerCustomSerializerTest.java
+++ b/basic/tcp-client-server/src/test/java/org/springframework/integration/samples/tcpclientserver/TcpServerCustomSerializerTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/basic/tcp-client-server/src/test/java/org/springframework/integration/samples/tcpclientserver/support/CustomTestContextLoader.java
+++ b/basic/tcp-client-server/src/test/java/org/springframework/integration/samples/tcpclientserver/support/CustomTestContextLoader.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/basic/testing-examples/src/main/java/org/springframework/integration/samples/testing/aggregator/CommaDelimitedAggregator.java
+++ b/basic/testing-examples/src/main/java/org/springframework/integration/samples/testing/aggregator/CommaDelimitedAggregator.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/basic/testing-examples/src/main/java/org/springframework/integration/samples/testing/externalgateway/Main.java
+++ b/basic/testing-examples/src/main/java/org/springframework/integration/samples/testing/externalgateway/Main.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/basic/testing-examples/src/main/java/org/springframework/integration/samples/testing/externalgateway/Traffic.java
+++ b/basic/testing-examples/src/main/java/org/springframework/integration/samples/testing/externalgateway/Traffic.java
@@ -5,7 +5,7 @@
  *     you may not use this file except in compliance with the License.
  *     You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  *     Unless required by applicable law or agreed to in writing, software
  *     distributed under the License is distributed on an "AS IS" BASIS,

--- a/basic/testing-examples/src/main/java/org/springframework/integration/samples/testing/externalgateway/TrafficHttpConverter.java
+++ b/basic/testing-examples/src/main/java/org/springframework/integration/samples/testing/externalgateway/TrafficHttpConverter.java
@@ -5,7 +5,7 @@
  *     you may not use this file except in compliance with the License.
  *     You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  *     Unless required by applicable law or agreed to in writing, software
  *     distributed under the License is distributed on an "AS IS" BASIS,

--- a/basic/testing-examples/src/main/java/org/springframework/integration/samples/testing/externalgateway/Weather.java
+++ b/basic/testing-examples/src/main/java/org/springframework/integration/samples/testing/externalgateway/Weather.java
@@ -5,7 +5,7 @@
  *     you may not use this file except in compliance with the License.
  *     You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  *     Unless required by applicable law or agreed to in writing, software
  *     distributed under the License is distributed on an "AS IS" BASIS,

--- a/basic/testing-examples/src/main/java/org/springframework/integration/samples/testing/externalgateway/WeatherAndTraffic.java
+++ b/basic/testing-examples/src/main/java/org/springframework/integration/samples/testing/externalgateway/WeatherAndTraffic.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/basic/testing-examples/src/main/java/org/springframework/integration/samples/testing/externalgateway/WeatherMarshaller.java
+++ b/basic/testing-examples/src/main/java/org/springframework/integration/samples/testing/externalgateway/WeatherMarshaller.java
@@ -5,7 +5,7 @@
  *     you may not use this file except in compliance with the License.
  *     You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  *     Unless required by applicable law or agreed to in writing, software
  *     distributed under the License is distributed on an "AS IS" BASIS,

--- a/basic/testing-examples/src/main/java/org/springframework/integration/samples/testing/filter/PetFilter.java
+++ b/basic/testing-examples/src/main/java/org/springframework/integration/samples/testing/filter/PetFilter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/basic/testing-examples/src/main/java/org/springframework/integration/samples/testing/gateway/VoidGateway.java
+++ b/basic/testing-examples/src/main/java/org/springframework/integration/samples/testing/gateway/VoidGateway.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/basic/testing-examples/src/main/java/org/springframework/integration/samples/testing/router/PetRouter.java
+++ b/basic/testing-examples/src/main/java/org/springframework/integration/samples/testing/router/PetRouter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/basic/testing-examples/src/main/java/org/springframework/integration/samples/testing/splitter/CommaDelimitedSplitter.java
+++ b/basic/testing-examples/src/main/java/org/springframework/integration/samples/testing/splitter/CommaDelimitedSplitter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/basic/testing-examples/src/test/java/org/springframework/integration/samples/testing/aggregator/CommaDelimitedAggregatorTests.java
+++ b/basic/testing-examples/src/test/java/org/springframework/integration/samples/testing/aggregator/CommaDelimitedAggregatorTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/basic/testing-examples/src/test/java/org/springframework/integration/samples/testing/chain/SpelChainTests.java
+++ b/basic/testing-examples/src/test/java/org/springframework/integration/samples/testing/chain/SpelChainTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/basic/testing-examples/src/test/java/org/springframework/integration/samples/testing/errorhandling/GatewayTests.java
+++ b/basic/testing-examples/src/test/java/org/springframework/integration/samples/testing/errorhandling/GatewayTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/basic/testing-examples/src/test/java/org/springframework/integration/samples/testing/externalgateway/ExternalGatewaySubstitutionTests.java
+++ b/basic/testing-examples/src/test/java/org/springframework/integration/samples/testing/externalgateway/ExternalGatewaySubstitutionTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/basic/testing-examples/src/test/java/org/springframework/integration/samples/testing/filter/PetFilterTests.java
+++ b/basic/testing-examples/src/test/java/org/springframework/integration/samples/testing/filter/PetFilterTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/basic/testing-examples/src/test/java/org/springframework/integration/samples/testing/gateway/GatewayTests.java
+++ b/basic/testing-examples/src/test/java/org/springframework/integration/samples/testing/gateway/GatewayTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/basic/testing-examples/src/test/java/org/springframework/integration/samples/testing/router/PetRouterTests.java
+++ b/basic/testing-examples/src/test/java/org/springframework/integration/samples/testing/router/PetRouterTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/basic/testing-examples/src/test/java/org/springframework/integration/samples/testing/splitter/CommaDelimitedSplitterTests.java
+++ b/basic/testing-examples/src/test/java/org/springframework/integration/samples/testing/splitter/CommaDelimitedSplitterTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/basic/twitter/src/test/java/org/springframework/integration/samples/twitter/TwitterSearchSample.java
+++ b/basic/twitter/src/test/java/org/springframework/integration/samples/twitter/TwitterSearchSample.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/basic/twitter/src/test/java/org/springframework/integration/samples/twitter/TwitterSendUpdatesSample.java
+++ b/basic/twitter/src/test/java/org/springframework/integration/samples/twitter/TwitterSendUpdatesSample.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/basic/twitter/src/test/java/org/springframework/integration/samples/twitter/TwitterTimelineUpdatesSample.java
+++ b/basic/twitter/src/test/java/org/springframework/integration/samples/twitter/TwitterTimelineUpdatesSample.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/basic/web-sockets/src/main/java/org/springframework/integration/samples/websocket/standard/client/Application.java
+++ b/basic/web-sockets/src/main/java/org/springframework/integration/samples/websocket/standard/client/Application.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/basic/web-sockets/src/main/java/org/springframework/integration/samples/websocket/standard/server/Application.java
+++ b/basic/web-sockets/src/main/java/org/springframework/integration/samples/websocket/standard/server/Application.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/basic/web-sockets/src/test/java/org/springframework/integration/samples/websocket/standard/ApplicationTests.java
+++ b/basic/web-sockets/src/test/java/org/springframework/integration/samples/websocket/standard/ApplicationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/basic/ws-inbound-gateway/src/main/java/org/springframework/integration/samples/ws/SimpleEchoResponder.java
+++ b/basic/ws-inbound-gateway/src/main/java/org/springframework/integration/samples/ws/SimpleEchoResponder.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/basic/ws-inbound-gateway/src/test/java/org/springframework/integration/samples/ws/InContainerTests.java
+++ b/basic/ws-inbound-gateway/src/test/java/org/springframework/integration/samples/ws/InContainerTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/basic/ws-inbound-gateway/src/test/java/org/springframework/integration/samples/ws/InboundGatewayTests.java
+++ b/basic/ws-inbound-gateway/src/test/java/org/springframework/integration/samples/ws/InboundGatewayTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/basic/ws-outbound-gateway/src/main/java/org/springframework/integration/samples/ws/WebServiceDemoTestApp.java
+++ b/basic/ws-outbound-gateway/src/main/java/org/springframework/integration/samples/ws/WebServiceDemoTestApp.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/basic/xml/src/main/java/org/springframework/integration/samples/xml/BookOrderProcessingTestApp.java
+++ b/basic/xml/src/main/java/org/springframework/integration/samples/xml/BookOrderProcessingTestApp.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/basic/xml/src/main/java/org/springframework/integration/samples/xml/ExternalResupply.java
+++ b/basic/xml/src/main/java/org/springframework/integration/samples/xml/ExternalResupply.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/basic/xml/src/main/java/org/springframework/integration/samples/xml/StockChecker.java
+++ b/basic/xml/src/main/java/org/springframework/integration/samples/xml/StockChecker.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/basic/xml/src/main/java/org/springframework/integration/samples/xml/WarehouseDispatch.java
+++ b/basic/xml/src/main/java/org/springframework/integration/samples/xml/WarehouseDispatch.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/basic/xml/src/main/java/org/springframework/integration/samples/xml/XmlUtil.java
+++ b/basic/xml/src/main/java/org/springframework/integration/samples/xml/XmlUtil.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/basic/xmpp/src/test/java/org/springframework/integration/samples/xmpp/ReceiveInstantMessageSample.java
+++ b/basic/xmpp/src/test/java/org/springframework/integration/samples/xmpp/ReceiveInstantMessageSample.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/basic/xmpp/src/test/java/org/springframework/integration/samples/xmpp/SendInstantMessageSample.java
+++ b/basic/xmpp/src/test/java/org/springframework/integration/samples/xmpp/SendInstantMessageSample.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/dsl/cafe-dsl/src/main/java/org/springframework/integration/samples/dsl/cafe/lambda/Application.java
+++ b/dsl/cafe-dsl/src/main/java/org/springframework/integration/samples/dsl/cafe/lambda/Application.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/dsl/cafe-dsl/src/main/java/org/springframework/integration/samples/dsl/cafe/nonlambda/Application.java
+++ b/dsl/cafe-dsl/src/main/java/org/springframework/integration/samples/dsl/cafe/nonlambda/Application.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/dsl/cafe-dsl/src/test/java/org/springframework/integration/samples/dsl/cafe/ApplicationTests.java
+++ b/dsl/cafe-dsl/src/test/java/org/springframework/integration/samples/dsl/cafe/ApplicationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/dsl/si4demo/src/main/java/org/springframework/integration/samples/si4demo/annotations/Application.java
+++ b/dsl/si4demo/src/main/java/org/springframework/integration/samples/si4demo/annotations/Application.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/dsl/si4demo/src/main/java/org/springframework/integration/samples/si4demo/dsl/Application.java
+++ b/dsl/si4demo/src/main/java/org/springframework/integration/samples/si4demo/dsl/Application.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/dsl/si4demo/src/main/java/org/springframework/integration/samples/si4demo/springone/GMailProperties.java
+++ b/dsl/si4demo/src/main/java/org/springframework/integration/samples/si4demo/springone/GMailProperties.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/dsl/si4demo/src/main/java/org/springframework/integration/samples/si4demo/springone/a/AXML.java
+++ b/dsl/si4demo/src/main/java/org/springframework/integration/samples/si4demo/springone/a/AXML.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/dsl/si4demo/src/main/java/org/springframework/integration/samples/si4demo/springone/b/BXMLAndPojo.java
+++ b/dsl/si4demo/src/main/java/org/springframework/integration/samples/si4demo/springone/b/BXMLAndPojo.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/dsl/si4demo/src/main/java/org/springframework/integration/samples/si4demo/springone/c/CNoXML.java
+++ b/dsl/si4demo/src/main/java/org/springframework/integration/samples/si4demo/springone/c/CNoXML.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/dsl/si4demo/src/main/java/org/springframework/integration/samples/si4demo/springone/d/DBoot.java
+++ b/dsl/si4demo/src/main/java/org/springframework/integration/samples/si4demo/springone/d/DBoot.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/dsl/si4demo/src/main/java/org/springframework/integration/samples/si4demo/springone/e/EDSL.java
+++ b/dsl/si4demo/src/main/java/org/springframework/integration/samples/si4demo/springone/e/EDSL.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/dsl/si4demo/src/main/java/org/springframework/integration/samples/si4demo/springone/f/FMail.java
+++ b/dsl/si4demo/src/main/java/org/springframework/integration/samples/si4demo/springone/f/FMail.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/dsl/si4demo/src/main/java/org/springframework/integration/samples/si4demo/springone/g/GIMAP.java
+++ b/dsl/si4demo/src/main/java/org/springframework/integration/samples/si4demo/springone/g/GIMAP.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/intermediate/async-gateway/src/main/java/org/springframework/integration/samples/async/gateway/MathService.java
+++ b/intermediate/async-gateway/src/main/java/org/springframework/integration/samples/async/gateway/MathService.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/intermediate/async-gateway/src/main/java/org/springframework/integration/samples/async/gateway/MathServiceGateway.java
+++ b/intermediate/async-gateway/src/main/java/org/springframework/integration/samples/async/gateway/MathServiceGateway.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/intermediate/async-gateway/src/test/java/org/springframework/integration/samples/async/gateway/AsyncGatewayTest.java
+++ b/intermediate/async-gateway/src/test/java/org/springframework/integration/samples/async/gateway/AsyncGatewayTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/intermediate/async-gateway/src/test/java/org/springframework/integration/samples/async/gateway/ListenableFutureTest.java
+++ b/intermediate/async-gateway/src/test/java/org/springframework/integration/samples/async/gateway/ListenableFutureTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/intermediate/async-gateway/src/test/java/org/springframework/integration/samples/async/gateway/PromiseTest.java
+++ b/intermediate/async-gateway/src/test/java/org/springframework/integration/samples/async/gateway/PromiseTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/intermediate/dynamic-poller/src/main/java/org/springframework/integration/samples/poller/DynamicPeriodicTrigger.java
+++ b/intermediate/dynamic-poller/src/main/java/org/springframework/integration/samples/poller/DynamicPeriodicTrigger.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/intermediate/dynamic-poller/src/main/java/org/springframework/integration/samples/poller/Main.java
+++ b/intermediate/dynamic-poller/src/main/java/org/springframework/integration/samples/poller/Main.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/intermediate/errorhandling/src/main/java/org/springframework/integration/samples/errorhandling/ErrorUnwrapper.java
+++ b/intermediate/errorhandling/src/main/java/org/springframework/integration/samples/errorhandling/ErrorUnwrapper.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/intermediate/errorhandling/src/main/java/org/springframework/integration/samples/errorhandling/Invitation.java
+++ b/intermediate/errorhandling/src/main/java/org/springframework/integration/samples/errorhandling/Invitation.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/intermediate/errorhandling/src/main/java/org/springframework/integration/samples/errorhandling/PartyGuest.java
+++ b/intermediate/errorhandling/src/main/java/org/springframework/integration/samples/errorhandling/PartyGuest.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/intermediate/errorhandling/src/main/java/org/springframework/integration/samples/errorhandling/PartyHost.java
+++ b/intermediate/errorhandling/src/main/java/org/springframework/integration/samples/errorhandling/PartyHost.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/intermediate/errorhandling/src/test/java/org/springframework/integration/samples/errorhandling/PartyDemoTest.java
+++ b/intermediate/errorhandling/src/test/java/org/springframework/integration/samples/errorhandling/PartyDemoTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/intermediate/mail-attachments/src/main/java/org/springframework/integration/samples/mailattachments/Main.java
+++ b/intermediate/mail-attachments/src/main/java/org/springframework/integration/samples/mailattachments/Main.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/intermediate/mail-attachments/src/main/java/org/springframework/integration/samples/mailattachments/support/EmailFragment.java
+++ b/intermediate/mail-attachments/src/main/java/org/springframework/integration/samples/mailattachments/support/EmailFragment.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/intermediate/mail-attachments/src/main/java/org/springframework/integration/samples/mailattachments/support/EmailParserUtils.java
+++ b/intermediate/mail-attachments/src/main/java/org/springframework/integration/samples/mailattachments/support/EmailParserUtils.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/intermediate/mail-attachments/src/main/java/org/springframework/integration/samples/mailattachments/support/EmailSplitter.java
+++ b/intermediate/mail-attachments/src/main/java/org/springframework/integration/samples/mailattachments/support/EmailSplitter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/intermediate/mail-attachments/src/main/java/org/springframework/integration/samples/mailattachments/support/EmailTransformer.java
+++ b/intermediate/mail-attachments/src/main/java/org/springframework/integration/samples/mailattachments/support/EmailTransformer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/intermediate/mail-attachments/src/test/java/org/springframework/integration/samples/mailattachments/MimeMessageParsingTest.java
+++ b/intermediate/mail-attachments/src/test/java/org/springframework/integration/samples/mailattachments/MimeMessageParsingTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/intermediate/monitoring/src/main/java/org/springframework/integration/mvc/controller/HomeController.java
+++ b/intermediate/monitoring/src/main/java/org/springframework/integration/mvc/controller/HomeController.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/intermediate/monitoring/src/main/java/org/springframework/integration/samples/storedprocedure/model/TwitterMessage.java
+++ b/intermediate/monitoring/src/main/java/org/springframework/integration/samples/storedprocedure/model/TwitterMessage.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/intermediate/monitoring/src/main/java/org/springframework/integration/samples/storedprocedure/service/TwitterService.java
+++ b/intermediate/monitoring/src/main/java/org/springframework/integration/samples/storedprocedure/service/TwitterService.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/intermediate/monitoring/src/main/java/org/springframework/integration/samples/storedprocedure/service/impl/DummyTwitter.java
+++ b/intermediate/monitoring/src/main/java/org/springframework/integration/samples/storedprocedure/service/impl/DummyTwitter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/intermediate/monitoring/src/main/java/org/springintegration/NotificationListener.java
+++ b/intermediate/monitoring/src/main/java/org/springintegration/NotificationListener.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/intermediate/monitoring/src/main/java/org/springintegration/PayloadAwareTimingInterceptor.java
+++ b/intermediate/monitoring/src/main/java/org/springintegration/PayloadAwareTimingInterceptor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/intermediate/monitoring/src/main/java/org/springintegration/SpringIntegrationTest.java
+++ b/intermediate/monitoring/src/main/java/org/springintegration/SpringIntegrationTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/intermediate/monitoring/src/main/java/org/springintegration/service/impl/DefaultTwitterService.java
+++ b/intermediate/monitoring/src/main/java/org/springintegration/service/impl/DefaultTwitterService.java
@@ -5,7 +5,7 @@
  *	 you may not use this file except in compliance with the License.
  *	 You may obtain a copy of the License at
  *
- *		 http://www.apache.org/licenses/LICENSE-2.0
+ *		 https://www.apache.org/licenses/LICENSE-2.0
  *
  *	 Unless required by applicable law or agreed to in writing, software
  *	 distributed under the License is distributed on an "AS IS" BASIS,

--- a/intermediate/multipart-http/src/main/java/org/springframework/integration/samples/multipart/MultipartReceiver.java
+++ b/intermediate/multipart-http/src/main/java/org/springframework/integration/samples/multipart/MultipartReceiver.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/intermediate/multipart-http/src/main/java/org/springframework/integration/samples/multipart/MultipartRequestGateway.java
+++ b/intermediate/multipart-http/src/main/java/org/springframework/integration/samples/multipart/MultipartRequestGateway.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/intermediate/multipart-http/src/test/java/org/springframework/integration/samples/multipart/MultipartClientForHttpOutboundClient.java
+++ b/intermediate/multipart-http/src/test/java/org/springframework/integration/samples/multipart/MultipartClientForHttpOutboundClient.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/intermediate/multipart-http/src/test/java/org/springframework/integration/samples/multipart/MultipartRestClient.java
+++ b/intermediate/multipart-http/src/test/java/org/springframework/integration/samples/multipart/MultipartRestClient.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/intermediate/rest-http/src/main/java/org/springframework/integration/samples/rest/domain/Employee.java
+++ b/intermediate/rest-http/src/main/java/org/springframework/integration/samples/rest/domain/Employee.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/intermediate/rest-http/src/main/java/org/springframework/integration/samples/rest/domain/EmployeeList.java
+++ b/intermediate/rest-http/src/main/java/org/springframework/integration/samples/rest/domain/EmployeeList.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/intermediate/rest-http/src/main/java/org/springframework/integration/samples/rest/json/JaxbJacksonObjectMapper.java
+++ b/intermediate/rest-http/src/main/java/org/springframework/integration/samples/rest/json/JaxbJacksonObjectMapper.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/intermediate/rest-http/src/main/java/org/springframework/integration/samples/rest/json/view/ExtendedMappingJacksonJsonView.java
+++ b/intermediate/rest-http/src/main/java/org/springframework/integration/samples/rest/json/view/ExtendedMappingJacksonJsonView.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/intermediate/rest-http/src/main/java/org/springframework/integration/samples/rest/service/EmployeeSearchService.java
+++ b/intermediate/rest-http/src/main/java/org/springframework/integration/samples/rest/service/EmployeeSearchService.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/intermediate/rest-http/src/test/java/org/springframework/integration/samples/rest/RestHttpClientTest.java
+++ b/intermediate/rest-http/src/test/java/org/springframework/integration/samples/rest/RestHttpClientTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/intermediate/retry-and-more/src/main/java/org/springframework/integration/samples/advice/CircuitBreakerDemo.java
+++ b/intermediate/retry-and-more/src/main/java/org/springframework/integration/samples/advice/CircuitBreakerDemo.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/intermediate/retry-and-more/src/main/java/org/springframework/integration/samples/advice/ConditionalService.java
+++ b/intermediate/retry-and-more/src/main/java/org/springframework/integration/samples/advice/ConditionalService.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/intermediate/retry-and-more/src/main/java/org/springframework/integration/samples/advice/FileTransferDeleteAfterSuccessDemo.java
+++ b/intermediate/retry-and-more/src/main/java/org/springframework/integration/samples/advice/FileTransferDeleteAfterSuccessDemo.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/intermediate/retry-and-more/src/main/java/org/springframework/integration/samples/advice/FileTransferRenameAfterFailureDemo.java
+++ b/intermediate/retry-and-more/src/main/java/org/springframework/integration/samples/advice/FileTransferRenameAfterFailureDemo.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/intermediate/retry-and-more/src/main/java/org/springframework/integration/samples/advice/StatefulRetryDemo.java
+++ b/intermediate/retry-and-more/src/main/java/org/springframework/integration/samples/advice/StatefulRetryDemo.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/intermediate/retry-and-more/src/main/java/org/springframework/integration/samples/advice/StatelessRetryDemo.java
+++ b/intermediate/retry-and-more/src/main/java/org/springframework/integration/samples/advice/StatelessRetryDemo.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/intermediate/splitter-aggregator-reaper/src/main/java/org/springframework/integration/samples/splitteraggregator/CompositeResult.java
+++ b/intermediate/splitter-aggregator-reaper/src/main/java/org/springframework/integration/samples/splitteraggregator/CompositeResult.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/intermediate/splitter-aggregator-reaper/src/main/java/org/springframework/integration/samples/splitteraggregator/Main.java
+++ b/intermediate/splitter-aggregator-reaper/src/main/java/org/springframework/integration/samples/splitteraggregator/Main.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/intermediate/splitter-aggregator-reaper/src/main/java/org/springframework/integration/samples/splitteraggregator/Result.java
+++ b/intermediate/splitter-aggregator-reaper/src/main/java/org/springframework/integration/samples/splitteraggregator/Result.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/intermediate/splitter-aggregator-reaper/src/main/java/org/springframework/integration/samples/splitteraggregator/SearchA.java
+++ b/intermediate/splitter-aggregator-reaper/src/main/java/org/springframework/integration/samples/splitteraggregator/SearchA.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/intermediate/splitter-aggregator-reaper/src/main/java/org/springframework/integration/samples/splitteraggregator/SearchB.java
+++ b/intermediate/splitter-aggregator-reaper/src/main/java/org/springframework/integration/samples/splitteraggregator/SearchB.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/intermediate/splitter-aggregator-reaper/src/main/java/org/springframework/integration/samples/splitteraggregator/SearchRequestSplitter.java
+++ b/intermediate/splitter-aggregator-reaper/src/main/java/org/springframework/integration/samples/splitteraggregator/SearchRequestSplitter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/intermediate/splitter-aggregator-reaper/src/main/java/org/springframework/integration/samples/splitteraggregator/SearchRequestor.java
+++ b/intermediate/splitter-aggregator-reaper/src/main/java/org/springframework/integration/samples/splitteraggregator/SearchRequestor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/intermediate/splitter-aggregator-reaper/src/main/java/org/springframework/integration/samples/splitteraggregator/SearchResultAggregator.java
+++ b/intermediate/splitter-aggregator-reaper/src/main/java/org/springframework/integration/samples/splitteraggregator/SearchResultAggregator.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/intermediate/splitter-aggregator-reaper/src/main/java/org/springframework/integration/samples/splitteraggregator/support/AbstractCriteria.java
+++ b/intermediate/splitter-aggregator-reaper/src/main/java/org/springframework/integration/samples/splitteraggregator/support/AbstractCriteria.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/intermediate/splitter-aggregator-reaper/src/main/java/org/springframework/integration/samples/splitteraggregator/support/CompositeCriteria.java
+++ b/intermediate/splitter-aggregator-reaper/src/main/java/org/springframework/integration/samples/splitteraggregator/support/CompositeCriteria.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/intermediate/splitter-aggregator-reaper/src/main/java/org/springframework/integration/samples/splitteraggregator/support/CriteriaA.java
+++ b/intermediate/splitter-aggregator-reaper/src/main/java/org/springframework/integration/samples/splitteraggregator/support/CriteriaA.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/intermediate/splitter-aggregator-reaper/src/main/java/org/springframework/integration/samples/splitteraggregator/support/CriteriaB.java
+++ b/intermediate/splitter-aggregator-reaper/src/main/java/org/springframework/integration/samples/splitteraggregator/support/CriteriaB.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/intermediate/splitter-aggregator-reaper/src/main/java/org/springframework/integration/samples/splitteraggregator/support/TestUtils.java
+++ b/intermediate/splitter-aggregator-reaper/src/main/java/org/springframework/integration/samples/splitteraggregator/support/TestUtils.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/intermediate/splitter-aggregator-reaper/src/test/java/org/springframework/integration/samples/splitteraggregator/TestSplitterAggregator.java
+++ b/intermediate/splitter-aggregator-reaper/src/test/java/org/springframework/integration/samples/splitteraggregator/TestSplitterAggregator.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/intermediate/stored-procedures-derby/src/main/java/org/springframework/integration/samples/storedprocedure/Main.java
+++ b/intermediate/stored-procedures-derby/src/main/java/org/springframework/integration/samples/storedprocedure/Main.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/intermediate/stored-procedures-derby/src/main/java/org/springframework/integration/samples/storedprocedure/jdbc/storedproc/derby/DerbyStoredProcedures.java
+++ b/intermediate/stored-procedures-derby/src/main/java/org/springframework/integration/samples/storedprocedure/jdbc/storedproc/derby/DerbyStoredProcedures.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/intermediate/stored-procedures-derby/src/main/java/org/springframework/integration/samples/storedprocedure/model/CoffeeBeverage.java
+++ b/intermediate/stored-procedures-derby/src/main/java/org/springframework/integration/samples/storedprocedure/model/CoffeeBeverage.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/intermediate/stored-procedures-derby/src/main/java/org/springframework/integration/samples/storedprocedure/service/CoffeeService.java
+++ b/intermediate/stored-procedures-derby/src/main/java/org/springframework/integration/samples/storedprocedure/service/CoffeeService.java
@@ -5,7 +5,7 @@
  *     you may not use this file except in compliance with the License.
  *     You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  *     Unless required by applicable law or agreed to in writing, software
  *     distributed under the License is distributed on an "AS IS" BASIS,

--- a/intermediate/stored-procedures-derby/src/main/java/org/springframework/integration/samples/storedprocedure/support/CoffeBeverageMapper.java
+++ b/intermediate/stored-procedures-derby/src/main/java/org/springframework/integration/samples/storedprocedure/support/CoffeBeverageMapper.java
@@ -4,7 +4,7 @@
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/intermediate/stored-procedures-derby/src/test/java/org/springframework/integration/CoffeeServiceFindAllTest.java
+++ b/intermediate/stored-procedures-derby/src/test/java/org/springframework/integration/CoffeeServiceFindAllTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/intermediate/stored-procedures-derby/src/test/java/org/springframework/integration/CoffeeServiceFindCoffeeTest.java
+++ b/intermediate/stored-procedures-derby/src/test/java/org/springframework/integration/CoffeeServiceFindCoffeeTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/intermediate/stored-procedures-derby/src/test/java/org/springframework/integration/CoffeeServiceStartupTest.java
+++ b/intermediate/stored-procedures-derby/src/test/java/org/springframework/integration/CoffeeServiceStartupTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/intermediate/stored-procedures-ms/src/main/java/org/springframework/integration/samples/storedprocedure/Main.java
+++ b/intermediate/stored-procedures-ms/src/main/java/org/springframework/integration/samples/storedprocedure/Main.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/intermediate/stored-procedures-ms/src/main/java/org/springframework/integration/samples/storedprocedure/service/StringConversionService.java
+++ b/intermediate/stored-procedures-ms/src/main/java/org/springframework/integration/samples/storedprocedure/service/StringConversionService.java
@@ -5,7 +5,7 @@
  *     you may not use this file except in compliance with the License.
  *     You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  *     Unless required by applicable law or agreed to in writing, software
  *     distributed under the License is distributed on an "AS IS" BASIS,

--- a/intermediate/stored-procedures-ms/src/test/java/org/springframework/integration/samples/StringConversionServiceTest.java
+++ b/intermediate/stored-procedures-ms/src/test/java/org/springframework/integration/samples/StringConversionServiceTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/intermediate/stored-procedures-oracle/src/main/java/org/springframework/integration/samples/storedprocedure/Main.java
+++ b/intermediate/stored-procedures-oracle/src/main/java/org/springframework/integration/samples/storedprocedure/Main.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/intermediate/stored-procedures-oracle/src/main/java/org/springframework/integration/samples/storedprocedure/model/CoffeeBeverage.java
+++ b/intermediate/stored-procedures-oracle/src/main/java/org/springframework/integration/samples/storedprocedure/model/CoffeeBeverage.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/intermediate/stored-procedures-oracle/src/main/java/org/springframework/integration/samples/storedprocedure/service/CoffeeService.java
+++ b/intermediate/stored-procedures-oracle/src/main/java/org/springframework/integration/samples/storedprocedure/service/CoffeeService.java
@@ -5,7 +5,7 @@
  *     you may not use this file except in compliance with the License.
  *     You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  *     Unless required by applicable law or agreed to in writing, software
  *     distributed under the License is distributed on an "AS IS" BASIS,

--- a/intermediate/stored-procedures-oracle/src/main/java/org/springframework/integration/samples/storedprocedure/service/StringConversionService.java
+++ b/intermediate/stored-procedures-oracle/src/main/java/org/springframework/integration/samples/storedprocedure/service/StringConversionService.java
@@ -5,7 +5,7 @@
  *     you may not use this file except in compliance with the License.
  *     You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  *     Unless required by applicable law or agreed to in writing, software
  *     distributed under the License is distributed on an "AS IS" BASIS,

--- a/intermediate/stored-procedures-oracle/src/main/java/org/springframework/integration/samples/storedprocedure/support/CoffeBeverageMapper.java
+++ b/intermediate/stored-procedures-oracle/src/main/java/org/springframework/integration/samples/storedprocedure/support/CoffeBeverageMapper.java
@@ -4,7 +4,7 @@
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/intermediate/stored-procedures-oracle/src/test/java/org/springframework/integration/sts/StringConversionServiceTest.java
+++ b/intermediate/stored-procedures-oracle/src/test/java/org/springframework/integration/sts/StringConversionServiceTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/intermediate/stored-procedures-postgresql/src/main/java/org/springframework/integration/samples/storedprocedure/Main.java
+++ b/intermediate/stored-procedures-postgresql/src/main/java/org/springframework/integration/samples/storedprocedure/Main.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/intermediate/stored-procedures-postgresql/src/main/java/org/springframework/integration/samples/storedprocedure/model/CoffeeBeverage.java
+++ b/intermediate/stored-procedures-postgresql/src/main/java/org/springframework/integration/samples/storedprocedure/model/CoffeeBeverage.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/intermediate/stored-procedures-postgresql/src/main/java/org/springframework/integration/samples/storedprocedure/service/CoffeeService.java
+++ b/intermediate/stored-procedures-postgresql/src/main/java/org/springframework/integration/samples/storedprocedure/service/CoffeeService.java
@@ -5,7 +5,7 @@
  *     you may not use this file except in compliance with the License.
  *     You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  *     Unless required by applicable law or agreed to in writing, software
  *     distributed under the License is distributed on an "AS IS" BASIS,

--- a/intermediate/stored-procedures-postgresql/src/main/java/org/springframework/integration/samples/storedprocedure/support/CoffeBeverageMapper.java
+++ b/intermediate/stored-procedures-postgresql/src/main/java/org/springframework/integration/samples/storedprocedure/support/CoffeBeverageMapper.java
@@ -4,7 +4,7 @@
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/intermediate/tcp-client-server-multiplex/src/main/java/org/springframework/integration/samples/tcpclientserver/ByteArrayToStringConverter.java
+++ b/intermediate/tcp-client-server-multiplex/src/main/java/org/springframework/integration/samples/tcpclientserver/ByteArrayToStringConverter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/intermediate/tcp-client-server-multiplex/src/main/java/org/springframework/integration/samples/tcpclientserver/EchoService.java
+++ b/intermediate/tcp-client-server-multiplex/src/main/java/org/springframework/integration/samples/tcpclientserver/EchoService.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/intermediate/tcp-client-server-multiplex/src/main/java/org/springframework/integration/samples/tcpclientserver/SimpleGateway.java
+++ b/intermediate/tcp-client-server-multiplex/src/main/java/org/springframework/integration/samples/tcpclientserver/SimpleGateway.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/intermediate/tcp-client-server-multiplex/src/test/java/org/springframework/integration/samples/tcpclientserver/TcpClientServerDemoTest.java
+++ b/intermediate/tcp-client-server-multiplex/src/test/java/org/springframework/integration/samples/tcpclientserver/TcpClientServerDemoTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/intermediate/tcp-client-server-multiplex/src/test/java/org/springframework/integration/samples/tcpclientserver/support/CustomTestContextLoader.java
+++ b/intermediate/tcp-client-server-multiplex/src/test/java/org/springframework/integration/samples/tcpclientserver/support/CustomTestContextLoader.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/intermediate/travel/src/main/java/org/springframework/integration/samples/travel/City.java
+++ b/intermediate/travel/src/main/java/org/springframework/integration/samples/travel/City.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/intermediate/travel/src/main/java/org/springframework/integration/samples/travel/Main.java
+++ b/intermediate/travel/src/main/java/org/springframework/integration/samples/travel/Main.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/intermediate/travel/src/main/java/org/springframework/integration/samples/travel/TravelGateway.java
+++ b/intermediate/travel/src/main/java/org/springframework/integration/samples/travel/TravelGateway.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/intermediate/travel/src/main/java/org/springframework/integration/samples/travel/TravelUtils.java
+++ b/intermediate/travel/src/main/java/org/springframework/integration/samples/travel/TravelUtils.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/intermediate/travel/src/main/java/org/springframework/integration/samples/travel/WeatherRequestTransformer.java
+++ b/intermediate/travel/src/main/java/org/springframework/integration/samples/travel/WeatherRequestTransformer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/intermediate/travel/src/test/java/org/springframework/integration/samples/travel/TravelGatewayTest.java
+++ b/intermediate/travel/src/test/java/org/springframework/integration/samples/travel/TravelGatewayTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/intermediate/tx-synch/src/main/java/org/springframework/integration/samples/advice/ConditionalService.java
+++ b/intermediate/tx-synch/src/main/java/org/springframework/integration/samples/advice/ConditionalService.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/intermediate/tx-synch/src/main/java/org/springframework/integration/samples/advice/TransactionSynchronizationDemo.java
+++ b/intermediate/tx-synch/src/main/java/org/springframework/integration/samples/advice/TransactionSynchronizationDemo.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://www.apache.org/licenses/LICENSE-2.0 with 292 occurrences migrated to:  
  https://www.apache.org/licenses/LICENSE-2.0 ([https](https://www.apache.org/licenses/LICENSE-2.0) result 200).