### PR TITLE
remove traces of old pre Java 8 Cafe DSL sample

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -722,13 +722,9 @@ project('cafe-dsl') {
 
 		testCompile 'org.springframework.boot:spring-boot-starter-test'
 	}
+
 	bootRun {
 		main = 'org.springframework.integration.samples.dsl.cafe.lambda.Application'
-	}
-
-	task run(type: JavaExec) {
-		main 'org.springframework.integration.samples.dsl.cafe.nonlambda.Application'
-		classpath = sourceSets.main.runtimeClasspath
 	}
 
 	tasks.withType(JavaExec) {

--- a/dsl/cafe-dsl/README.md
+++ b/dsl/cafe-dsl/README.md
@@ -12,7 +12,4 @@ See the `cafe` project **README.md** for more details about the domain and the C
 Main class --> Run As --> Java Application)
 * or from the command line:
 
-    $ gradlew :cafe-dsl:run
-
-There is the second similar sample - `org.springframework.integration.samples.dsl.cafe.nonlambda.Application`, which
-demonstrates how Spring Integration Java DSL can be used from pre Java 8 environment.
+    $ gradlew :cafe-dsl:bootRun


### PR DESCRIPTION
Removes traces of old `org.springframework.integration.samples.dsl.cafe.nonlambda.Application` from Cafe DSL sample.