### PR TITLE
Fix Barrier with Boot 2.3

### DIFF
--- a/basic/barrier/src/main/java/org/springframework/integration/samples/barrier/Application.java
+++ b/basic/barrier/src/main/java/org/springframework/integration/samples/barrier/Application.java
@@ -37,6 +37,11 @@ public class Application {
 	public static void main(String[] args) throws Exception {
 		ConfigurableApplicationContext server = SpringApplication.run(Application.class, args);
 
+		runClient(args);
+		server.close();
+	}
+
+	static void runClient(String[] args) {
 		SpringApplication application = new SpringApplicationBuilder()
 				.web(WebApplicationType.NONE)
 				.bannerMode(Mode.OFF)
@@ -52,8 +57,6 @@ public class Application {
 		String reply = requestGateway.echo(request);
 		System.out.println("\n\n++++++++++++ Replied with: " + reply + " ++++++++++++\n");
 		client.close();
-		server.close();
-		System.exit(0); // AMQP-519
 	}
 
 

--- a/basic/barrier/src/main/resources/application.properties
+++ b/basic/barrier/src/main/resources/application.properties
@@ -1,4 +1,4 @@
 spring.output.ansi.enabled=always
 
-spring.rabbitmq.publisher-confirms=true
+spring.rabbitmq.publisher-confirm-type=correlated
 spring.rabbitmq.publisher-returns=true

--- a/basic/barrier/src/test/java/org/springframework/integration/samples/barrier/ApplicationTests.java
+++ b/basic/barrier/src/test/java/org/springframework/integration/samples/barrier/ApplicationTests.java
@@ -16,10 +16,20 @@
 
 package org.springframework.integration.samples.barrier;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Collections;
+
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.integration.channel.AbstractMessageChannel;
+import org.springframework.integration.channel.QueueChannel;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.MessageHeaders;
+import org.springframework.messaging.support.GenericMessage;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 /**
@@ -30,8 +40,18 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE, classes = Application.class)
 public class ApplicationTests {
 
+	@Autowired
+	MessageChannel receiveChannel;
+
+	@Autowired
+	AbstractMessageChannel release;
+
 	@Test
-	public void contextLoads() {
+	public void contextLoads() throws InterruptedException {
+		QueueChannel replies = new QueueChannel();
+		receiveChannel.send(
+				new GenericMessage<>("A,B,C", Collections.singletonMap(MessageHeaders.REPLY_CHANNEL, replies)));
+		assertThat(replies.receive(10_000)).isNotNull();
 	}
 
 }


### PR DESCRIPTION
- deprecated property was removed in Boot 2.3, but there was no test to verify operation.