### PR TITLE
Prevent the users from running into CORS errors 

### DIFF
--- a/basic/web-sockets/README.md
+++ b/basic/web-sockets/README.md
@@ -21,7 +21,7 @@ The `org.springframework.integration.samples.websocket.standard.client.Applicati
 ## Browser Client
    
 The `index.html` in the `src/main/resources/static` directory of this project demonstrates a JavaScript `SockJS` client, which connects
-to our server and just prints its messages in the middle of page.
+to our server and just prints its messages in the middle of page. It can be reached at http://localhost:8080/index.html.
  
 ## Test Case
 


### PR DESCRIPTION
by providing the URL (host/path) where they can easily test the Browser Client.