### PR TITLE
Remove Netty dependency exclude from tests

### DIFF
--- a/basic/grpc-client/src/test/java/org/springframework/integration/samples/grpc/client/GrpcClientTests.java
+++ b/basic/grpc-client/src/test/java/org/springframework/integration/samples/grpc/client/GrpcClientTests.java
@@ -37,11 +37,7 @@ import static org.awaitility.Awaitility.await;
  *
  * @author Glenn Renfro
  */
-@SpringBootTest(properties = {
-		"spring.grpc.server.inprocess.name=test",
-		"spring.grpc.client.channels.spring-integration.address=in-process:test"
-
-})
+@SpringBootTest
 @DirtiesContext
 @ExtendWith(OutputCaptureExtension.class)
 @AutoConfigureTestGrpcTransport

--- a/basic/grpc-client/src/test/java/org/springframework/integration/samples/grpc/client/GrpcClientTests.java
+++ b/basic/grpc-client/src/test/java/org/springframework/integration/samples/grpc/client/GrpcClientTests.java
@@ -21,6 +21,7 @@ import java.time.Duration;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
+import org.springframework.boot.grpc.test.autoconfigure.AutoConfigureTestGrpcTransport;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.boot.test.system.CapturedOutput;
@@ -39,9 +40,11 @@ import static org.awaitility.Awaitility.await;
 @SpringBootTest(properties = {
 		"spring.grpc.server.inprocess.name=test",
 		"spring.grpc.client.channels.spring-integration.address=in-process:test"
+
 })
 @DirtiesContext
 @ExtendWith(OutputCaptureExtension.class)
+@AutoConfigureTestGrpcTransport
 public class GrpcClientTests {
 
 	/**

--- a/basic/grpc-server/src/test/java/org/springframework/integration/samples/grpc/server/GrpcServerTests.java
+++ b/basic/grpc-server/src/test/java/org/springframework/integration/samples/grpc/server/GrpcServerTests.java
@@ -28,6 +28,7 @@ import org.apache.commons.logging.LogFactory;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.grpc.test.autoconfigure.AutoConfigureTestGrpcTransport;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.grpc.client.ImportGrpcClients;
 
@@ -48,6 +49,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 		},
 		target = "in-process:test"
 )
+@AutoConfigureTestGrpcTransport
 class GrpcServerTests {
 
 	private static final Log LOGGER = LogFactory.getLog(GrpcServerTests.class);

--- a/basic/grpc-server/src/test/java/org/springframework/integration/samples/grpc/server/GrpcServerTests.java
+++ b/basic/grpc-server/src/test/java/org/springframework/integration/samples/grpc/server/GrpcServerTests.java
@@ -39,16 +39,12 @@ import static org.assertj.core.api.Assertions.assertThat;
  *
  * @author Glenn Renfro
  */
-@SpringBootTest({
-		"spring.grpc.server.inprocess.name=test"
-})
+@SpringBootTest
 @ImportGrpcClients(
 		types = {
 				SimpleGrpc.SimpleBlockingStub.class,
 				SimpleGrpc.SimpleStub.class
-		},
-		target = "in-process:test"
-)
+		})
 @AutoConfigureTestGrpcTransport
 class GrpcServerTests {
 

--- a/build.gradle
+++ b/build.gradle
@@ -891,9 +891,7 @@ project('grpc-client') {
 		implementation 'org.springframework.integration:spring-integration-grpc'
 
 		//Test
-		testImplementation ('org.springframework.boot:spring-boot-starter-grpc-test') {
-			exclude group: 'io.grpc', module: 'grpc-netty' //TODO Review this exclusion prior to 7.1.0 release
-		}
+		testImplementation ('org.springframework.boot:spring-boot-starter-grpc-test')
 	}
 
 
@@ -946,9 +944,7 @@ project('grpc-server') {
 		implementation 'org.springframework.integration:spring-integration-grpc'
 
 		//Test
-		testImplementation ('org.springframework.boot:spring-boot-starter-grpc-test') {
-			exclude group: 'io.grpc', module: 'grpc-netty' //TODO Review this exclusion prior to 7.1.0 release
-		}
+		testImplementation ('org.springframework.boot:spring-boot-starter-grpc-test')
 	}
 
 	protobuf {


### PR DESCRIPTION
To disable the activation of the Netty server when using the inprocess server  add `@AutoConfigureTestGrpcTransport` to the test.

<!--
Thanks for contributing to Spring Integration Samples. 
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/main/CONTRIBUTING.adoc).
-->
